### PR TITLE
Fixes crash bug with Username Logger when a non-player is nearby

### DIFF
--- a/1.7.10/src/main/java/net/geforcemods/securitycraft/tileentity/TileEntityLogger.java
+++ b/1.7.10/src/main/java/net/geforcemods/securitycraft/tileentity/TileEntityLogger.java
@@ -22,7 +22,11 @@ public class TileEntityLogger extends TileEntityOwnable {
 	}
 	
 	public boolean canAttack() {
-		return worldObj.isBlockIndirectlyGettingPowered(xCoord, yCoord, zCoord);
+                if (worldObj != null) {
+		    return worldObj.isBlockIndirectlyGettingPowered(xCoord, yCoord, zCoord);
+                } else {
+                    return false;
+                }
 	}
 	
 	private void addPlayerName(String username){

--- a/1.7.10/src/main/java/net/geforcemods/securitycraft/tileentity/TileEntityLogger.java
+++ b/1.7.10/src/main/java/net/geforcemods/securitycraft/tileentity/TileEntityLogger.java
@@ -12,8 +12,10 @@ public class TileEntityLogger extends TileEntityOwnable {
 	
 	public boolean attackEntity(Entity entity) {		
 		if (!this.worldObj.isRemote) {		
-        	addPlayerName(((EntityPlayer) entity).getCommandSenderName());
-        	sendChangeToClient();
+			if (entity instanceof EntityPlayer) {
+		        	addPlayerName(((EntityPlayer) entity).getCommandSenderName());
+		        	sendChangeToClient();
+			}
 		}
 		
 		return true;


### PR DESCRIPTION
Hi Guys,

Just experienced this crashbug, please let me know if the patch is not what is required.

This is to fix:

`---- Minecraft Crash Report ----
// This doesn't make any sense!

Time: 03/04/16 03:09
Description: Ticking block entity

java.lang.ClassCastException: net.minecraft.entity.monster.EntitySpider cannot be cast to net.minecraft.entity.player.EntityPlayer
        at net.geforcemods.securitycraft.tileentity.TileEntityLogger.attackEntity(TileEntityLogger.java:15)
        at net.geforcemods.securitycraft.api.TileEntitySCTE.func_145845_h(TileEntitySCTE.java:102)
        at net.minecraft.world.World.func_72939_s(World.java:2548)
        at net.minecraft.world.WorldServer.func_72939_s(WorldServer.java:673)
        at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:976)
        at net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:431)
        at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:831)
        at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:683)
        at java.lang.Thread.run(Thread.java:745)


A detailed walkthrough of the error, its code path and all known details is as follows:
---------------------------------------------------------------------------------------

-- Head --
Stacktrace:
        at net.geforcemods.securitycraft.tileentity.TileEntityLogger.attackEntity(TileEntityLogger.java:15)
        at net.geforcemods.securitycraft.api.TileEntitySCTE.func_145845_h(TileEntitySCTE.java:102)

`
Regards,

DraksterAU