### PR TITLE
Fix possible channel spying with /sc connect

### DIFF
--- a/1.10.2/src/main/java/net/geforcemods/securitycraft/ircbot/SCIRCBot.java
+++ b/1.10.2/src/main/java/net/geforcemods/securitycraft/ircbot/SCIRCBot.java
@@ -32,7 +32,7 @@ public class SCIRCBot extends PircBot{
 	public void connectToChannel() throws IOException, IrcException, NickAlreadyInUseException{
 		this.connect("irc.esper.net");
 		this.joinChannel("#GeforceMods");
-		this.setVerbose(true);
+		this.setVerbose(false);
 
 		if(Minecraft.getMinecraft().getSession().getToken() == null)
 			sendMessage("#GeforceMods", "I am using a cracked client! (No Session token found.)");

--- a/1.11.2/src/main/java/net/geforcemods/securitycraft/ircbot/SCIRCBot.java
+++ b/1.11.2/src/main/java/net/geforcemods/securitycraft/ircbot/SCIRCBot.java
@@ -32,7 +32,7 @@ public class SCIRCBot extends PircBot{
 	public void connectToChannel() throws IOException, IrcException, NickAlreadyInUseException{
 		this.connect("irc.esper.net");
 		this.joinChannel("#GeforceMods");
-		this.setVerbose(true);
+		this.setVerbose(false);
 
 		if(Minecraft.getMinecraft().getSession().getToken() == null)
 			sendMessage("#GeforceMods", "I am using a cracked client! (No Session token found.)");

--- a/1.12.1/src/main/java/net/geforcemods/securitycraft/ircbot/SCIRCBot.java
+++ b/1.12.1/src/main/java/net/geforcemods/securitycraft/ircbot/SCIRCBot.java
@@ -32,7 +32,7 @@ public class SCIRCBot extends PircBot{
 	public void connectToChannel() throws IOException, IrcException, NickAlreadyInUseException{
 		this.connect("irc.esper.net");
 		this.joinChannel("#GeforceMods");
-		this.setVerbose(true);
+		this.setVerbose(false);
 
 		if(Minecraft.getMinecraft().getSession().getToken() == null)
 			sendMessage("#GeforceMods", "I am using a cracked client! (No Session token found.)");

--- a/1.7.10/src/main/java/net/geforcemods/securitycraft/ircbot/SCIRCBot.java
+++ b/1.7.10/src/main/java/net/geforcemods/securitycraft/ircbot/SCIRCBot.java
@@ -33,7 +33,7 @@ public class SCIRCBot extends PircBot{
 	public void connectToChannel() throws IOException, IrcException, NickAlreadyInUseException{
 		this.connect("irc.esper.net");
 		this.joinChannel("#GeforceMods");
-		this.setVerbose(true);
+		this.setVerbose(false);
 
 		if(Minecraft.getMinecraft().getSession().getToken() == null)
 			sendMessage("#GeforceMods", "I am using a cracked client! (No Session token found.)");

--- a/1.8.8/src/main/java/net/geforcemods/securitycraft/ircbot/SCIRCBot.java
+++ b/1.8.8/src/main/java/net/geforcemods/securitycraft/ircbot/SCIRCBot.java
@@ -32,7 +32,7 @@ public class SCIRCBot extends PircBot{
 	public void connectToChannel() throws IOException, IrcException, NickAlreadyInUseException{
 		this.connect("irc.esper.net");
 		this.joinChannel("#GeforceMods");
-		this.setVerbose(true);
+		this.setVerbose(false);
 
 		if(Minecraft.getMinecraft().getSession().getToken() == null)
 			sendMessage("#GeforceMods", "I am using a cracked client! (No Session token found.)");

--- a/1.8/src/main/java/net/geforcemods/securitycraft/ircbot/SCIRCBot.java
+++ b/1.8/src/main/java/net/geforcemods/securitycraft/ircbot/SCIRCBot.java
@@ -32,7 +32,7 @@ public class SCIRCBot extends PircBot{
 	public void connectToChannel() throws IOException, IrcException, NickAlreadyInUseException{
 		this.connect("irc.esper.net");
 		this.joinChannel("#GeforceMods");
-		this.setVerbose(true);
+		this.setVerbose(false);
 
 		if(Minecraft.getMinecraft().getSession().getToken() == null)
 			sendMessage("#GeforceMods", "I am using a cracked client! (No Session token found.)");


### PR DESCRIPTION
This PR disables PircBots verbose logging that would allow the user to potentially spy on other conversations in the IRC channel by looking into their Minecraft log files.