### PR TITLE
[WIP] Fix for sentry's head Y translation after exit

### DIFF
--- a/src/main/java/net/geforcemods/securitycraft/entity/EntitySentry.java
+++ b/src/main/java/net/geforcemods/securitycraft/entity/EntitySentry.java
@@ -44,7 +44,6 @@ public class EntitySentry extends EntityCreature implements IRangedAttackMob //n
 	private static final DataParameter<NBTTagCompound> WHITELIST = EntityDataManager.<NBTTagCompound>createKey(EntitySentry.class, DataSerializers.COMPOUND_TAG);
 	private static final DataParameter<Integer> MODE = EntityDataManager.<Integer>createKey(EntitySentry.class, DataSerializers.VARINT);
 	public static final DataParameter<Float> HEAD_ROTATION = EntityDataManager.<Float>createKey(EntitySentry.class, DataSerializers.FLOAT);
-	public static final DataParameter<Float> HEAD_TRANSLATION = EntityDataManager.<Float>createKey(EntitySentry.class, DataSerializers.FLOAT);
 	public static final float MAX_TARGET_DISTANCE = 20.0F;
 	private float headYTranslation = 0.9F;
 	private final float animationStepSize = 0.025F;
@@ -72,7 +71,6 @@ public class EntitySentry extends EntityCreature implements IRangedAttackMob //n
 		dataManager.set(WHITELIST, new NBTTagCompound());
 		dataManager.set(MODE, EnumSentryMode.CAMOUFLAGE.ordinal());
 		dataManager.set(HEAD_ROTATION, 0.0F);
-		dataManager.set(HEAD_TRANSLATION, 0.9F);
 	}
 
 	@Override
@@ -84,7 +82,6 @@ public class EntitySentry extends EntityCreature implements IRangedAttackMob //n
 		dataManager.register(WHITELIST, new NBTTagCompound());
 		dataManager.register(MODE, EnumSentryMode.CAMOUFLAGE.ordinal());
 		dataManager.register(HEAD_ROTATION, 0.0F);
-		dataManager.register(HEAD_TRANSLATION, 0.9F);
 	}
 
 	@Override
@@ -99,17 +96,11 @@ public class EntitySentry extends EntityCreature implements IRangedAttackMob //n
 	{
 		super.onEntityUpdate();
 
-//		if (dataManager.get(MODE) == 0 && headYTranslation > 0.0F && !animate) {
-//			animate = true;
-//			animateUpwards = true;
-//		}
-		
 		if(world.isRemote && animate)
 		{
-			if(animateUpwards && dataManager.get(HEAD_TRANSLATION) > 0.0F)
+			if(animateUpwards && headYTranslation > 0.0F)
 			{
 				headYTranslation -= animationStepSize;
-				dataManager.set(HEAD_TRANSLATION, headYTranslation);
 
 				if(headYTranslation <= 0.0F)
 				{
@@ -117,10 +108,9 @@ public class EntitySentry extends EntityCreature implements IRangedAttackMob //n
 					animate = false;
 				}
 			}
-			else if(!animateUpwards && dataManager.get(HEAD_TRANSLATION) < 0.9F)
+			else if(!animateUpwards && headYTranslation < 0.9F)
 			{
 				headYTranslation += animationStepSize;
-				dataManager.set(HEAD_TRANSLATION, headYTranslation);
 
 				if(headYTranslation >= 0.9F)
 				{
@@ -292,7 +282,6 @@ public class EntitySentry extends EntityCreature implements IRangedAttackMob //n
 		tag.setTag("InstalledWhitelist", getWhitelistModule().writeToNBT(new NBTTagCompound()));
 		tag.setInteger("SentryMode", dataManager.get(MODE));
 		tag.setFloat("HeadRotation", dataManager.get(HEAD_ROTATION));
-		tag.setFloat("HeadTranslation", dataManager.get(HEAD_TRANSLATION));
 		super.writeEntityToNBT(tag);
 	}
 
@@ -318,7 +307,6 @@ public class EntitySentry extends EntityCreature implements IRangedAttackMob //n
 		dataManager.set(WHITELIST, (NBTTagCompound)tag.getTag("InstalledWhitelist"));
 		dataManager.set(MODE, tag.getInteger("SentryMode"));
 		dataManager.set(HEAD_ROTATION, tag.getFloat("HeadRotation"));
-		dataManager.set(HEAD_TRANSLATION, tag.getFloat("HeadTranslation"));
 		super.readEntityFromNBT(tag);
 	}
 
@@ -399,8 +387,7 @@ public class EntitySentry extends EntityCreature implements IRangedAttackMob //n
 	 */
 	public float getHeadYTranslation()
 	{
-		return dataManager.get(HEAD_TRANSLATION);
-		//return headYTranslation;
+		return headYTranslation;
 	}
 
 	public boolean isTargetingWhitelistedPlayer(EntityLivingBase potentialTarget)

--- a/src/main/java/net/geforcemods/securitycraft/entity/EntitySentry.java
+++ b/src/main/java/net/geforcemods/securitycraft/entity/EntitySentry.java
@@ -103,7 +103,6 @@ public class EntitySentry extends EntityCreature implements IRangedAttackMob //n
 				animateUpwards = true;
 				animate = true;
 			}
-			
 			if (animate)
 			{
 				if(animateUpwards && headYTranslation > 0.0F)

--- a/src/main/java/net/geforcemods/securitycraft/entity/EntitySentry.java
+++ b/src/main/java/net/geforcemods/securitycraft/entity/EntitySentry.java
@@ -96,26 +96,35 @@ public class EntitySentry extends EntityCreature implements IRangedAttackMob //n
 	{
 		super.onEntityUpdate();
 
-		if(world.isRemote && animate)
+		if(world.isRemote)
 		{
-			if(animateUpwards && headYTranslation > 0.0F)
+			if (dataManager.get(MODE) == 0 && headYTranslation > 0.0F && !animate)
 			{
-				headYTranslation -= animationStepSize;
-
-				if(headYTranslation <= 0.0F)
-				{
-					animateUpwards = false;
-					animate = false;
-				}
+				animateUpwards = true;
+				animate = true;
 			}
-			else if(!animateUpwards && headYTranslation < 0.9F)
+			
+			if (animate)
 			{
-				headYTranslation += animationStepSize;
-
-				if(headYTranslation >= 0.9F)
+				if(animateUpwards && headYTranslation > 0.0F)
 				{
-					animateUpwards = true;
-					animate = false;
+					headYTranslation -= animationStepSize;
+	
+					if(headYTranslation <= 0.0F)
+					{
+						animateUpwards = false;
+						animate = false;
+					}
+				}
+				else if(!animateUpwards && headYTranslation < 0.9F)
+				{
+					headYTranslation += animationStepSize;
+	
+					if(headYTranslation >= 0.9F)
+					{
+						animateUpwards = true;
+						animate = false;
+					}
 				}
 			}
 		}

--- a/src/main/java/net/geforcemods/securitycraft/entity/EntitySentry.java
+++ b/src/main/java/net/geforcemods/securitycraft/entity/EntitySentry.java
@@ -44,6 +44,7 @@ public class EntitySentry extends EntityCreature implements IRangedAttackMob //n
 	private static final DataParameter<NBTTagCompound> WHITELIST = EntityDataManager.<NBTTagCompound>createKey(EntitySentry.class, DataSerializers.COMPOUND_TAG);
 	private static final DataParameter<Integer> MODE = EntityDataManager.<Integer>createKey(EntitySentry.class, DataSerializers.VARINT);
 	public static final DataParameter<Float> HEAD_ROTATION = EntityDataManager.<Float>createKey(EntitySentry.class, DataSerializers.FLOAT);
+	public static final DataParameter<Float> HEAD_TRANSLATION = EntityDataManager.<Float>createKey(EntitySentry.class, DataSerializers.FLOAT);
 	public static final float MAX_TARGET_DISTANCE = 20.0F;
 	private float headYTranslation = 0.9F;
 	private final float animationStepSize = 0.025F;
@@ -71,6 +72,7 @@ public class EntitySentry extends EntityCreature implements IRangedAttackMob //n
 		dataManager.set(WHITELIST, new NBTTagCompound());
 		dataManager.set(MODE, EnumSentryMode.CAMOUFLAGE.ordinal());
 		dataManager.set(HEAD_ROTATION, 0.0F);
+		dataManager.set(HEAD_TRANSLATION, 0.9F);
 	}
 
 	@Override
@@ -82,6 +84,7 @@ public class EntitySentry extends EntityCreature implements IRangedAttackMob //n
 		dataManager.register(WHITELIST, new NBTTagCompound());
 		dataManager.register(MODE, EnumSentryMode.CAMOUFLAGE.ordinal());
 		dataManager.register(HEAD_ROTATION, 0.0F);
+		dataManager.register(HEAD_TRANSLATION, 0.9F);
 	}
 
 	@Override
@@ -96,11 +99,17 @@ public class EntitySentry extends EntityCreature implements IRangedAttackMob //n
 	{
 		super.onEntityUpdate();
 
+//		if (dataManager.get(MODE) == 0 && headYTranslation > 0.0F && !animate) {
+//			animate = true;
+//			animateUpwards = true;
+//		}
+		
 		if(world.isRemote && animate)
 		{
-			if(animateUpwards && headYTranslation > 0.0F)
+			if(animateUpwards && dataManager.get(HEAD_TRANSLATION) > 0.0F)
 			{
 				headYTranslation -= animationStepSize;
+				dataManager.set(HEAD_TRANSLATION, headYTranslation);
 
 				if(headYTranslation <= 0.0F)
 				{
@@ -108,9 +117,10 @@ public class EntitySentry extends EntityCreature implements IRangedAttackMob //n
 					animate = false;
 				}
 			}
-			else if(!animateUpwards && headYTranslation < 0.9F)
+			else if(!animateUpwards && dataManager.get(HEAD_TRANSLATION) < 0.9F)
 			{
 				headYTranslation += animationStepSize;
+				dataManager.set(HEAD_TRANSLATION, headYTranslation);
 
 				if(headYTranslation >= 0.9F)
 				{
@@ -282,6 +292,7 @@ public class EntitySentry extends EntityCreature implements IRangedAttackMob //n
 		tag.setTag("InstalledWhitelist", getWhitelistModule().writeToNBT(new NBTTagCompound()));
 		tag.setInteger("SentryMode", dataManager.get(MODE));
 		tag.setFloat("HeadRotation", dataManager.get(HEAD_ROTATION));
+		tag.setFloat("HeadTranslation", dataManager.get(HEAD_TRANSLATION));
 		super.writeEntityToNBT(tag);
 	}
 
@@ -307,6 +318,7 @@ public class EntitySentry extends EntityCreature implements IRangedAttackMob //n
 		dataManager.set(WHITELIST, (NBTTagCompound)tag.getTag("InstalledWhitelist"));
 		dataManager.set(MODE, tag.getInteger("SentryMode"));
 		dataManager.set(HEAD_ROTATION, tag.getFloat("HeadRotation"));
+		dataManager.set(HEAD_TRANSLATION, tag.getFloat("HeadTranslation"));
 		super.readEntityFromNBT(tag);
 	}
 
@@ -387,7 +399,8 @@ public class EntitySentry extends EntityCreature implements IRangedAttackMob //n
 	 */
 	public float getHeadYTranslation()
 	{
-		return headYTranslation;
+		return dataManager.get(HEAD_TRANSLATION);
+		//return headYTranslation;
 	}
 
 	public boolean isTargetingWhitelistedPlayer(EntityLivingBase potentialTarget)

--- a/src/main/java/net/geforcemods/securitycraft/models/ModelSentry.java
+++ b/src/main/java/net/geforcemods/securitycraft/models/ModelSentry.java
@@ -60,7 +60,8 @@ public class ModelSentry extends ModelBase
 		if(entity instanceof EntitySentry)
 		{
 			GlStateManager.rotate(((EntitySentry)entity).getDataManager().get(EntitySentry.HEAD_ROTATION), 0.0F, 1.0F, 0.0F);
-			GlStateManager.translate(0.0F, ((EntitySentry)entity).getHeadYTranslation(), 0.0F);
+			//GlStateManager.translate(0.0F, ((EntitySentry)entity).getHeadYTranslation(), 0.0F);
+			GlStateManager.translate(0.0F, ((EntitySentry)entity).getDataManager().get(EntitySentry.HEAD_TRANSLATION), 0.0F);
 		}
 
 		head.render(scale);

--- a/src/main/java/net/geforcemods/securitycraft/models/ModelSentry.java
+++ b/src/main/java/net/geforcemods/securitycraft/models/ModelSentry.java
@@ -60,8 +60,7 @@ public class ModelSentry extends ModelBase
 		if(entity instanceof EntitySentry)
 		{
 			GlStateManager.rotate(((EntitySentry)entity).getDataManager().get(EntitySentry.HEAD_ROTATION), 0.0F, 1.0F, 0.0F);
-			//GlStateManager.translate(0.0F, ((EntitySentry)entity).getHeadYTranslation(), 0.0F);
-			GlStateManager.translate(0.0F, ((EntitySentry)entity).getDataManager().get(EntitySentry.HEAD_TRANSLATION), 0.0F);
+			GlStateManager.translate(0.0F, ((EntitySentry)entity).getHeadYTranslation(), 0.0F);
 		}
 
 		head.render(scale);


### PR DESCRIPTION
Little graphic bug regarding sentries. If you set your sentry to agressive mode, it successfully animates upwards. However, if you exit the server and enter again, the sentry's head will be hidden because the Y translation is not saved, and so it seems the sentry is in either camouflage or idle mode. This does not affect operation, it still attacks mobs&players.

This PR is work in progress, because I'm having some trouble finding the ideal solution. I have two possible different approaches, both with its pros and cons

1. First solution would be to save head Y translation to NBT, as it's done with the head rotation
   - _Pros_: I'd say this would be the expected approach. It should have minimal performance impact
   - _Cons_: **it doesn't work**. Better said, I can't make it work, because I'm sure there's something I'm missing, but I truly can find the problem. Animation works fine when toggling mode, so renderer is correctly reading the `HEAD_TRANSLATION` at that time. But if you exit and enter the server, the head would be just hidden no matter what, so seems a problem while writing/reading to/from NBT. Also, I'm not sure if this fix is totally backwards compatible, since already created sentries wouldn't have the associated NBT tag, so they would be initially assigned the default value which may or may not be the correct one depending on their mode.

2. Second solution would involve no changes, just 4 new lines (ignore they're commented...) (https://github.com/LorenaGdL/SecurityCraft/blob/eaf0fa3afee11ddc7f12d23c5f5d370ce63c6921/src/main/java/net/geforcemods/securitycraft/entity/EntitySentry.java#L102-L105)

    - _Cons_: involves specifically checking for the issue (aggressive mode but head down) in each update, while it's a problem only present on init. So not efficient, though it's just a check...
    - _Pros_: simple and **it works**. Also, it would also prevent/fix an even rarer bug that could theoretically happen in solution 1 when you exit the server in the middle of the upwards animation, saving a half-way head Y position to NBT.

I'd appreciate if you could throw some light on this... Please, don't hate me too much 