### PR TITLE
[FIX] Removed gap in Cage Trap east side

### DIFF
--- a/src/main/java/net/geforcemods/securitycraft/util/BlockUtils.java
+++ b/src/main/java/net/geforcemods/securitycraft/util/BlockUtils.java
@@ -67,9 +67,6 @@ public class BlockUtils{
 		BlockUtils.setBlock(world, x, y + 1, z + 1, block);
 		BlockUtils.setBlock(world, x, y + 2, z + 1, block);
 		BlockUtils.setBlock(world, x, y + 3, z + 1, block);
-		BlockUtils.setBlock(world, x + 1, y + 1, z, block);
-		BlockUtils.setBlock(world, x + 1, y + 2, z, block);
-		BlockUtils.setBlock(world, x + 1, y + 3, z, block);
 
 		BlockUtils.setBlock(world, x, y + 1, z - 1, block);
 		BlockUtils.setBlock(world, x, y + 2, z - 1, block);


### PR DESCRIPTION
Those blocks are set twice, and that seems to mess with the connections/blockstate properties in 1.14.4. In 1.12.2 that doesn't seem to cause a bug, although I'd remove the lines too as they're not needed.