### PR TITLE
[FIX][MINOR] Prevent JEI half-error when initializing

### DIFF
--- a/src/main/java/net/geforcemods/securitycraft/network/ClientProxy.java
+++ b/src/main/java/net/geforcemods/securitycraft/network/ClientProxy.java
@@ -132,7 +132,7 @@ public class ClientProxy implements IProxy {
 		toTint.forEach((block, tint) -> Minecraft.getInstance().getBlockColors().register((state, world, pos, tintIndex) -> tint, block));
 		toTint.forEach((item, tint) -> Minecraft.getInstance().getItemColors().register((stack, tintIndex) -> tint, item));
 		Minecraft.getInstance().getBlockColors().register((state, world, pos, tintIndex) -> {
-			Block block = world.getBlockState(pos).getBlock();
+			Block block = state.getBlock();
 
 			if(block instanceof DisguisableBlock)
 			{


### PR DESCRIPTION
Well, it seems `world` and `pos` can be null, and they're indeed null when JEI initializes and access the function (at least in my tests), so it throws the NullPointerException error (though JEI uses a try-catch and everything is fine):

```
@OnlyIn(Dist.CLIENT)
public interface IBlockColor {
   int getColor(BlockState p_getColor_1_, @Nullable IEnviromentBlockReader p_getColor_2_, @Nullable BlockPos p_getColor_3_, int p_getColor_4_);
}
```

But anyway, there's no need to use `world` and `pos` to get the BlockState since it's already provided as input