### PR TITLE
[FIX] Mines no longer drop when an entity breaks them

### DIFF
--- a/src/generated/resources/data/securitycraft/loot_tables/blocks/bouncing_betty.json
+++ b/src/generated/resources/data/securitycraft/loot_tables/blocks/bouncing_betty.json
@@ -12,6 +12,14 @@
       "conditions": [
         {
           "condition": "minecraft:survives_explosion"
+        },
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:entity_properties",
+            "predicate": {},
+            "entity": "this"
+          }
         }
       ]
     }

--- a/src/generated/resources/data/securitycraft/loot_tables/blocks/claymore.json
+++ b/src/generated/resources/data/securitycraft/loot_tables/blocks/claymore.json
@@ -12,6 +12,14 @@
       "conditions": [
         {
           "condition": "minecraft:survives_explosion"
+        },
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:entity_properties",
+            "predicate": {},
+            "entity": "this"
+          }
         }
       ]
     }

--- a/src/generated/resources/data/securitycraft/loot_tables/blocks/cobblestone_mine.json
+++ b/src/generated/resources/data/securitycraft/loot_tables/blocks/cobblestone_mine.json
@@ -12,6 +12,14 @@
       "conditions": [
         {
           "condition": "minecraft:survives_explosion"
+        },
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:entity_properties",
+            "predicate": {},
+            "entity": "this"
+          }
         }
       ]
     }

--- a/src/generated/resources/data/securitycraft/loot_tables/blocks/diamond_mine.json
+++ b/src/generated/resources/data/securitycraft/loot_tables/blocks/diamond_mine.json
@@ -12,6 +12,14 @@
       "conditions": [
         {
           "condition": "minecraft:survives_explosion"
+        },
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:entity_properties",
+            "predicate": {},
+            "entity": "this"
+          }
         }
       ]
     }

--- a/src/generated/resources/data/securitycraft/loot_tables/blocks/dirt_mine.json
+++ b/src/generated/resources/data/securitycraft/loot_tables/blocks/dirt_mine.json
@@ -12,6 +12,14 @@
       "conditions": [
         {
           "condition": "minecraft:survives_explosion"
+        },
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:entity_properties",
+            "predicate": {},
+            "entity": "this"
+          }
         }
       ]
     }

--- a/src/generated/resources/data/securitycraft/loot_tables/blocks/furnace_mine.json
+++ b/src/generated/resources/data/securitycraft/loot_tables/blocks/furnace_mine.json
@@ -12,6 +12,14 @@
       "conditions": [
         {
           "condition": "minecraft:survives_explosion"
+        },
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:entity_properties",
+            "predicate": {},
+            "entity": "this"
+          }
         }
       ]
     }

--- a/src/generated/resources/data/securitycraft/loot_tables/blocks/gravel_mine.json
+++ b/src/generated/resources/data/securitycraft/loot_tables/blocks/gravel_mine.json
@@ -12,6 +12,14 @@
       "conditions": [
         {
           "condition": "minecraft:survives_explosion"
+        },
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:entity_properties",
+            "predicate": {},
+            "entity": "this"
+          }
         }
       ]
     }

--- a/src/generated/resources/data/securitycraft/loot_tables/blocks/mine.json
+++ b/src/generated/resources/data/securitycraft/loot_tables/blocks/mine.json
@@ -12,6 +12,14 @@
       "conditions": [
         {
           "condition": "minecraft:survives_explosion"
+        },
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:entity_properties",
+            "predicate": {},
+            "entity": "this"
+          }
         }
       ]
     }

--- a/src/generated/resources/data/securitycraft/loot_tables/blocks/sand_mine.json
+++ b/src/generated/resources/data/securitycraft/loot_tables/blocks/sand_mine.json
@@ -12,6 +12,14 @@
       "conditions": [
         {
           "condition": "minecraft:survives_explosion"
+        },
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:entity_properties",
+            "predicate": {},
+            "entity": "this"
+          }
         }
       ]
     }

--- a/src/generated/resources/data/securitycraft/loot_tables/blocks/stone_mine.json
+++ b/src/generated/resources/data/securitycraft/loot_tables/blocks/stone_mine.json
@@ -12,6 +12,14 @@
       "conditions": [
         {
           "condition": "minecraft:survives_explosion"
+        },
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:entity_properties",
+            "predicate": {},
+            "entity": "this"
+          }
         }
       ]
     }

--- a/src/generated/resources/data/securitycraft/loot_tables/blocks/track_mine.json
+++ b/src/generated/resources/data/securitycraft/loot_tables/blocks/track_mine.json
@@ -12,6 +12,14 @@
       "conditions": [
         {
           "condition": "minecraft:survives_explosion"
+        },
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:entity_properties",
+            "predicate": {},
+            "entity": "this"
+          }
         }
       ]
     }

--- a/src/main/java/net/geforcemods/securitycraft/datagen/BlockLootTableGenerator.java
+++ b/src/main/java/net/geforcemods/securitycraft/datagen/BlockLootTableGenerator.java
@@ -18,11 +18,14 @@ import net.minecraft.state.properties.DoubleBlockHalf;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.storage.loot.ConstantRange;
 import net.minecraft.world.storage.loot.ItemLootEntry;
+import net.minecraft.world.storage.loot.LootContext.EntityTarget;
 import net.minecraft.world.storage.loot.LootParameterSets;
 import net.minecraft.world.storage.loot.LootPool;
 import net.minecraft.world.storage.loot.LootTable;
 import net.minecraft.world.storage.loot.LootTableManager;
 import net.minecraft.world.storage.loot.conditions.BlockStateProperty;
+import net.minecraft.world.storage.loot.conditions.EntityHasProperty;
+import net.minecraft.world.storage.loot.conditions.Inverted;
 import net.minecraft.world.storage.loot.conditions.SurvivesExplosion;
 
 public class BlockLootTableGenerator implements IDataProvider
@@ -39,15 +42,15 @@ public class BlockLootTableGenerator implements IDataProvider
 	private void addTables()
 	{
 		putStandardBlockLootTable(SCContent.alarm);
-		putStandardBlockLootTable(SCContent.bouncingBetty);
+		putMineLootTable(SCContent.bouncingBetty);
 		putStandardBlockLootTable(SCContent.cageTrap);
-		putStandardBlockLootTable(SCContent.claymore);
-		putStandardBlockLootTable(SCContent.cobblestoneMine);
-		putStandardBlockLootTable(SCContent.diamondOreMine);
-		putStandardBlockLootTable(SCContent.dirtMine);
+		putMineLootTable(SCContent.claymore);
+		putMineLootTable(SCContent.cobblestoneMine);
+		putMineLootTable(SCContent.diamondOreMine);
+		putMineLootTable(SCContent.dirtMine);
 		putStandardBlockLootTable(SCContent.ironFence);
-		putStandardBlockLootTable(SCContent.furnaceMine);
-		putStandardBlockLootTable(SCContent.gravelMine);
+		putMineLootTable(SCContent.furnaceMine);
+		putMineLootTable(SCContent.gravelMine);
 		putStandardBlockLootTable(SCContent.inventoryScanner);
 		putDoorLootTable(SCContent.reinforcedDoor, SCContent.reinforcedDoorItem);
 		putStandardBlockLootTable(SCContent.keycardReader);
@@ -56,7 +59,7 @@ public class BlockLootTableGenerator implements IDataProvider
 		putStandardBlockLootTable(SCContent.keypadFurnace);
 		putStandardBlockLootTable(SCContent.keypad);
 		putStandardBlockLootTable(SCContent.laserBlock);
-		putStandardBlockLootTable(SCContent.mine);
+		putMineLootTable(SCContent.mine);
 		putStandardBlockLootTable(SCContent.motionActivatedLight);
 		putStandardBlockLootTable(SCContent.panicButton);
 		putStandardBlockLootTable(SCContent.portableRadar);
@@ -64,7 +67,7 @@ public class BlockLootTableGenerator implements IDataProvider
 		putStandardBlockLootTable(SCContent.reinforcedFencegate);
 		putStandardBlockLootTable(SCContent.reinforcedIronTrapdoor);
 		putStandardBlockLootTable(SCContent.retinalScanner);
-		putStandardBlockLootTable(SCContent.sandMine);
+		putMineLootTable(SCContent.sandMine);
 		putDoorLootTable(SCContent.scannerDoor, SCContent.scannerDoorItem);
 		putStandardBlockLootTable(SCContent.secretAcaciaSign);
 		putStandardBlockLootTable(SCContent.secretAcaciaWallSign);
@@ -79,8 +82,8 @@ public class BlockLootTableGenerator implements IDataProvider
 		putStandardBlockLootTable(SCContent.secretSpruceSign);
 		putStandardBlockLootTable(SCContent.secretSpruceWallSign);
 		putStandardBlockLootTable(SCContent.securityCamera);
-		putStandardBlockLootTable(SCContent.stoneMine);
-		putStandardBlockLootTable(SCContent.trackMine);
+		putMineLootTable(SCContent.stoneMine);
+		putMineLootTable(SCContent.trackMine);
 		putStandardBlockLootTable(SCContent.trophySystem);
 		putStandardBlockLootTable(SCContent.usernameLogger);
 	}
@@ -107,6 +110,16 @@ public class BlockLootTableGenerator implements IDataProvider
 	protected final void putStandardBlockLootTable(Block block)
 	{
 		lootTables.put(block, createStandardBlockLootTable(block));
+	}
+
+	protected final void putMineLootTable(Block mine)
+	{
+		lootTables.put(mine, LootTable.builder()
+				.addLootPool(LootPool.builder()
+						.rolls(ConstantRange.of(1))
+						.addEntry(ItemLootEntry.builder(mine))
+						.acceptCondition(SurvivesExplosion.builder())
+						.acceptCondition(Inverted.builder(EntityHasProperty.builder(EntityTarget.THIS)))));
 	}
 
 	@Override


### PR DESCRIPTION
Mines don't drop when an entity breaks them, but do drop when UBR's is used

New loot table condition checks if an entity broke the block, and if so it doesn't drop the item. Given how it's internally coded, using the UBR isn't technically the entity breaking the block, so the condition passes and lets the item drop.

I'm not completely familiar with all the mines' details, so if this change shouldn't apply to a certain kind, let me know.

--
_Note: In case you wonderered, the match_tool condition can't be used since again UBR doesn't really break the block in the traditional way (i.e. left-clicking) so the condition never passes._
