### PR TITLE
Add the stonecutting recipes of some reinforced blocks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,8 +109,8 @@ dependencies {
 	runtimeOnly fg.deobf("mcp.mobius.waila:Hwyla:1.10.8-B72_1.15.2")
     implementation fg.deobf("mcjty.theoneprobe:TheOneProbe-1.15:1.15-2.0.0-3")
     compileOnly fg.deobf("curse.maven:cyclic:2883170")
-	compileOnly fg.deobf("mezz.jei:jei-1.15.2:6.0.0.2:api")
-	runtimeOnly fg.deobf("mezz.jei:jei-1.15.2:6.0.0.2")
+	compileOnly fg.deobf("mezz.jei:jei-1.15.2:6.0.0.4:api")
+	runtimeOnly fg.deobf("mezz.jei:jei-1.15.2:6.0.0.4")
 }
 
 jar {

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/chiseled_crystal_quartz_from_crystal_quartz_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/chiseled_crystal_quartz_from_crystal_quartz_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:chiseled_crystal_quartz_from_crystal_quartz_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_crystal_quartz": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:crystal_quartz"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:chiseled_crystal_quartz_from_crystal_quartz_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_crystal_quartz",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/crystal_quartz_pillar_from_crystal_quartz_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/crystal_quartz_pillar_from_crystal_quartz_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:crystal_quartz_pillar_from_crystal_quartz_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_crystal_quartz": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:crystal_quartz"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:crystal_quartz_pillar_from_crystal_quartz_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_crystal_quartz",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/crystal_quartz_slab_from_crystal_quartz_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/crystal_quartz_slab_from_crystal_quartz_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:crystal_quartz_slab_from_crystal_quartz_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_crystal_quartz": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:crystal_quartz"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:crystal_quartz_slab_from_crystal_quartz_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_crystal_quartz",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/crystal_quartz_stairs_from_crystal_quartz_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/crystal_quartz_stairs_from_crystal_quartz_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:crystal_quartz_stairs_from_crystal_quartz_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_crystal_quartz": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:crystal_quartz"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:crystal_quartz_stairs_from_crystal_quartz_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_crystal_quartz",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_andesite_slab_from_reinforced_andesite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_andesite_slab_from_reinforced_andesite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_andesite_slab_from_reinforced_andesite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_andesite": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_andesite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_andesite_slab_from_reinforced_andesite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_andesite",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_andesite_stairs_from_reinforced_andesite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_andesite_stairs_from_reinforced_andesite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_andesite_stairs_from_reinforced_andesite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_andesite": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_andesite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_andesite_stairs_from_reinforced_andesite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_andesite",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_andesite_wall_from_reinforced_andesite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_andesite_wall_from_reinforced_andesite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_andesite_wall_from_reinforced_andesite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_andesite": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_andesite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_andesite_wall_from_reinforced_andesite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_andesite",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_brick_slab_from_reinforced_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_brick_slab_from_reinforced_bricks_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_brick_slab_from_reinforced_bricks_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_bricks": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_bricks"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_brick_slab_from_reinforced_bricks_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_bricks",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_brick_stairs_from_reinforced_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_brick_stairs_from_reinforced_bricks_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_brick_stairs_from_reinforced_bricks_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_bricks": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_bricks"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_brick_stairs_from_reinforced_bricks_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_bricks",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_brick_wall_from_reinforced_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_brick_wall_from_reinforced_bricks_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_brick_wall_from_reinforced_bricks_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_bricks": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_bricks"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_brick_wall_from_reinforced_bricks_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_bricks",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_chiseled_crystal_quartz_block_from_reinforced_crystal_quartz_block_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_chiseled_crystal_quartz_block_from_reinforced_crystal_quartz_block_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_chiseled_crystal_quartz_block_from_reinforced_crystal_quartz_block_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_crystal_quartz_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_crystal_quartz_block"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_chiseled_crystal_quartz_block_from_reinforced_crystal_quartz_block_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_crystal_quartz_block",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_chiseled_quartz_block_from_reinforced_quartz_block_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_chiseled_quartz_block_from_reinforced_quartz_block_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_chiseled_quartz_block_from_reinforced_quartz_block_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_quartz_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_quartz_block"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_chiseled_quartz_block_from_reinforced_quartz_block_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_quartz_block",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_chiseled_red_sandstone_from_reinforced_red_sandstone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_chiseled_red_sandstone_from_reinforced_red_sandstone_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_chiseled_red_sandstone_from_reinforced_red_sandstone_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_red_sandstone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_red_sandstone"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_chiseled_red_sandstone_from_reinforced_red_sandstone_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_red_sandstone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_chiseled_sandstone_from_reinforced_sandstone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_chiseled_sandstone_from_reinforced_sandstone_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_chiseled_sandstone_from_reinforced_sandstone_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_sandstone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_sandstone"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_chiseled_sandstone_from_reinforced_sandstone_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_sandstone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_chiseled_stone_bricks_from_reinforced_stone_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_chiseled_stone_bricks_from_reinforced_stone_bricks_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_chiseled_stone_bricks_from_reinforced_stone_bricks_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_stone_bricks": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_stone_bricks"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_chiseled_stone_bricks_from_reinforced_stone_bricks_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_stone_bricks",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_chiseled_stone_bricks_from_reinforced_stone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_chiseled_stone_bricks_from_reinforced_stone_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_chiseled_stone_bricks_from_reinforced_stone_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_stone"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_chiseled_stone_bricks_from_reinforced_stone_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_cobblestone_slab_from_reinforced_cobblestone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_cobblestone_slab_from_reinforced_cobblestone_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_cobblestone_slab_from_reinforced_cobblestone_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_cobblestone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_cobblestone"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_cobblestone_slab_from_reinforced_cobblestone_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_cobblestone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_cobblestone_stairs_from_reinforced_cobblestone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_cobblestone_stairs_from_reinforced_cobblestone_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_cobblestone_stairs_from_reinforced_cobblestone_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_cobblestone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_cobblestone"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_cobblestone_stairs_from_reinforced_cobblestone_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_cobblestone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_cobblestone_wall_from_reinforced_cobblestone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_cobblestone_wall_from_reinforced_cobblestone_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_cobblestone_wall_from_reinforced_cobblestone_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_cobblestone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_cobblestone"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_cobblestone_wall_from_reinforced_cobblestone_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_cobblestone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_crystal_quartz_pillar_from_reinforced_crystal_quartz_block_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_crystal_quartz_pillar_from_reinforced_crystal_quartz_block_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_crystal_quartz_pillar_from_reinforced_crystal_quartz_block_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_crystal_quartz_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_crystal_quartz_block"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_crystal_quartz_pillar_from_reinforced_crystal_quartz_block_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_crystal_quartz_block",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_crystal_quartz_slab_from_reinforced_crystal_quartz_block_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_crystal_quartz_slab_from_reinforced_crystal_quartz_block_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_crystal_quartz_slab_from_reinforced_crystal_quartz_block_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_crystal_quartz_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_crystal_quartz_block"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_crystal_quartz_slab_from_reinforced_crystal_quartz_block_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_crystal_quartz_block",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_crystal_quartz_stairs_from_reinforced_crystal_quartz_block_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_crystal_quartz_stairs_from_reinforced_crystal_quartz_block_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_crystal_quartz_stairs_from_reinforced_crystal_quartz_block_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_crystal_quartz_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_crystal_quartz_block"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_crystal_quartz_stairs_from_reinforced_crystal_quartz_block_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_crystal_quartz_block",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_cut_red_sandstone_from_reinforced_red_sandstone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_cut_red_sandstone_from_reinforced_red_sandstone_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_cut_red_sandstone_from_reinforced_red_sandstone_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_red_sandstone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_red_sandstone"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_cut_red_sandstone_from_reinforced_red_sandstone_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_red_sandstone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_cut_red_sandstone_slab_from_reinforced_cut_red_sandstone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_cut_red_sandstone_slab_from_reinforced_cut_red_sandstone_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_cut_red_sandstone_slab_from_reinforced_cut_red_sandstone_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_cut_red_sandstone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_cut_red_sandstone"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_cut_red_sandstone_slab_from_reinforced_cut_red_sandstone_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_cut_red_sandstone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_cut_red_sandstone_slab_from_reinforced_red_sandstone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_cut_red_sandstone_slab_from_reinforced_red_sandstone_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_cut_red_sandstone_slab_from_reinforced_red_sandstone_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_red_sandstone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_red_sandstone"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_cut_red_sandstone_slab_from_reinforced_red_sandstone_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_red_sandstone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_cut_sandstone_from_reinforced_sandstone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_cut_sandstone_from_reinforced_sandstone_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_cut_sandstone_from_reinforced_sandstone_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_sandstone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_sandstone"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_cut_sandstone_from_reinforced_sandstone_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_sandstone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_cut_sandstone_slab_from_reinforced_cut_sandstone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_cut_sandstone_slab_from_reinforced_cut_sandstone_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_cut_sandstone_slab_from_reinforced_cut_sandstone_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_cut_sandstone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_cut_sandstone"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_cut_sandstone_slab_from_reinforced_cut_sandstone_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_cut_sandstone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_cut_sandstone_slab_from_reinforced_sandstone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_cut_sandstone_slab_from_reinforced_sandstone_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_cut_sandstone_slab_from_reinforced_sandstone_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_sandstone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_sandstone"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_cut_sandstone_slab_from_reinforced_sandstone_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_sandstone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_dark_prismarine_slab_from_reinforced_dark_prismarine_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_dark_prismarine_slab_from_reinforced_dark_prismarine_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_dark_prismarine_slab_from_reinforced_dark_prismarine_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_dark_prismarine": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_dark_prismarine"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_dark_prismarine_slab_from_reinforced_dark_prismarine_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_dark_prismarine",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_dark_prismarine_stairs_from_reinforced_dark_prismarine_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_dark_prismarine_stairs_from_reinforced_dark_prismarine_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_dark_prismarine_stairs_from_reinforced_dark_prismarine_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_dark_prismarine": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_dark_prismarine"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_dark_prismarine_stairs_from_reinforced_dark_prismarine_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_dark_prismarine",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_diorite_slab_from_reinforced_diorite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_diorite_slab_from_reinforced_diorite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_diorite_slab_from_reinforced_diorite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_diorite": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_diorite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_diorite_slab_from_reinforced_diorite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_diorite",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_diorite_stairs_from_reinforced_diorite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_diorite_stairs_from_reinforced_diorite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_diorite_stairs_from_reinforced_diorite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_diorite": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_diorite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_diorite_stairs_from_reinforced_diorite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_diorite",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_diorite_wall_from_reinforced_diorite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_diorite_wall_from_reinforced_diorite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_diorite_wall_from_reinforced_diorite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_diorite": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_diorite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_diorite_wall_from_reinforced_diorite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_diorite",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_end_stone_brick_slab_from_reinforced_end_stone_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_end_stone_brick_slab_from_reinforced_end_stone_bricks_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_end_stone_brick_slab_from_reinforced_end_stone_bricks_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_end_stone_bricks": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_end_stone_bricks"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_end_stone_brick_slab_from_reinforced_end_stone_bricks_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_end_stone_bricks",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_end_stone_brick_slab_from_reinforced_end_stone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_end_stone_brick_slab_from_reinforced_end_stone_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_end_stone_brick_slab_from_reinforced_end_stone_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_end_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_end_stone"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_end_stone_brick_slab_from_reinforced_end_stone_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_end_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_end_stone_brick_stairs_from_reinforced_end_stone_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_end_stone_brick_stairs_from_reinforced_end_stone_bricks_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_end_stone_brick_stairs_from_reinforced_end_stone_bricks_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_end_stone_bricks": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_end_stone_bricks"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_end_stone_brick_stairs_from_reinforced_end_stone_bricks_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_end_stone_bricks",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_end_stone_brick_stairs_from_reinforced_end_stone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_end_stone_brick_stairs_from_reinforced_end_stone_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_end_stone_brick_stairs_from_reinforced_end_stone_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_end_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_end_stone"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_end_stone_brick_stairs_from_reinforced_end_stone_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_end_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_end_stone_brick_wall_from_reinforced_end_stone_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_end_stone_brick_wall_from_reinforced_end_stone_bricks_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_end_stone_brick_wall_from_reinforced_end_stone_bricks_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_end_stone_bricks": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_end_stone_bricks"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_end_stone_brick_wall_from_reinforced_end_stone_bricks_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_end_stone_bricks",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_end_stone_brick_wall_from_reinforced_end_stone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_end_stone_brick_wall_from_reinforced_end_stone_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_end_stone_brick_wall_from_reinforced_end_stone_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_end_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_end_stone"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_end_stone_brick_wall_from_reinforced_end_stone_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_end_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_end_stone_bricks_from_reinforced_end_stone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_end_stone_bricks_from_reinforced_end_stone_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_end_stone_bricks_from_reinforced_end_stone_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_end_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_end_stone"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_end_stone_bricks_from_reinforced_end_stone_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_end_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_granite_slab_from_reinforced_granite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_granite_slab_from_reinforced_granite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_granite_slab_from_reinforced_granite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_granite": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_granite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_granite_slab_from_reinforced_granite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_granite",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_granite_stairs_from_reinforced_granite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_granite_stairs_from_reinforced_granite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_granite_stairs_from_reinforced_granite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_granite": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_granite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_granite_stairs_from_reinforced_granite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_granite",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_granite_wall_from_reinforced_granite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_granite_wall_from_reinforced_granite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_granite_wall_from_reinforced_granite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_granite": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_granite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_granite_wall_from_reinforced_granite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_granite",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_mossy_cobblestone_slab_from_reinforced_mossy_cobblestone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_mossy_cobblestone_slab_from_reinforced_mossy_cobblestone_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_mossy_cobblestone_slab_from_reinforced_mossy_cobblestone_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_mossy_cobblestone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_mossy_cobblestone"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_mossy_cobblestone_slab_from_reinforced_mossy_cobblestone_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_mossy_cobblestone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_mossy_cobblestone_stairs_from_reinforced_mossy_cobblestone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_mossy_cobblestone_stairs_from_reinforced_mossy_cobblestone_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_mossy_cobblestone_stairs_from_reinforced_mossy_cobblestone_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_mossy_cobblestone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_mossy_cobblestone"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_mossy_cobblestone_stairs_from_reinforced_mossy_cobblestone_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_mossy_cobblestone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_mossy_cobblestone_wall_from_reinforced_mossy_cobblestone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_mossy_cobblestone_wall_from_reinforced_mossy_cobblestone_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_mossy_cobblestone_wall_from_reinforced_mossy_cobblestone_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_mossy_cobblestone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_mossy_cobblestone"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_mossy_cobblestone_wall_from_reinforced_mossy_cobblestone_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_mossy_cobblestone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_mossy_stone_brick_slab_from_reinforced_mossy_stone_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_mossy_stone_brick_slab_from_reinforced_mossy_stone_bricks_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_mossy_stone_brick_slab_from_reinforced_mossy_stone_bricks_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_mossy_stone_bricks": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_mossy_stone_bricks"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_mossy_stone_brick_slab_from_reinforced_mossy_stone_bricks_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_mossy_stone_bricks",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_mossy_stone_brick_stairs_from_reinforced_mossy_stone_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_mossy_stone_brick_stairs_from_reinforced_mossy_stone_bricks_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_mossy_stone_brick_stairs_from_reinforced_mossy_stone_bricks_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_mossy_stone_bricks": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_mossy_stone_bricks"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_mossy_stone_brick_stairs_from_reinforced_mossy_stone_bricks_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_mossy_stone_bricks",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_mossy_stone_brick_wall_from_reinforced_mossy_stone_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_mossy_stone_brick_wall_from_reinforced_mossy_stone_bricks_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_mossy_stone_brick_wall_from_reinforced_mossy_stone_bricks_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_mossy_stone_bricks": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_mossy_stone_bricks"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_mossy_stone_brick_wall_from_reinforced_mossy_stone_bricks_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_mossy_stone_bricks",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_nether_brick_slab_from_reinforced_nether_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_nether_brick_slab_from_reinforced_nether_bricks_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_nether_brick_slab_from_reinforced_nether_bricks_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_nether_bricks": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_nether_bricks"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_nether_brick_slab_from_reinforced_nether_bricks_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_nether_bricks",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_nether_brick_stairs_from_reinforced_nether_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_nether_brick_stairs_from_reinforced_nether_bricks_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_nether_brick_stairs_from_reinforced_nether_bricks_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_nether_bricks": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_nether_bricks"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_nether_brick_stairs_from_reinforced_nether_bricks_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_nether_bricks",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_nether_brick_wall_from_reinforced_nether_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_nether_brick_wall_from_reinforced_nether_bricks_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_nether_brick_wall_from_reinforced_nether_bricks_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_nether_bricks": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_nether_bricks"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_nether_brick_wall_from_reinforced_nether_bricks_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_nether_bricks",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_normal_stone_slab_from_reinforced_stone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_normal_stone_slab_from_reinforced_stone_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_normal_stone_slab_from_reinforced_stone_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_stone"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_normal_stone_slab_from_reinforced_stone_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_polished_andesite_from_reinforced_andesite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_polished_andesite_from_reinforced_andesite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_polished_andesite_from_reinforced_andesite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_andesite": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_andesite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_polished_andesite_from_reinforced_andesite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_andesite",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_polished_andesite_slab_from_reinforced_andesite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_polished_andesite_slab_from_reinforced_andesite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_polished_andesite_slab_from_reinforced_andesite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_andesite": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_andesite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_polished_andesite_slab_from_reinforced_andesite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_andesite",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_polished_andesite_slab_from_reinforced_polished_andesite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_polished_andesite_slab_from_reinforced_polished_andesite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_polished_andesite_slab_from_reinforced_polished_andesite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_polished_andesite": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_polished_andesite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_polished_andesite_slab_from_reinforced_polished_andesite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_polished_andesite",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_polished_andesite_stairs_from_reinforced_andesite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_polished_andesite_stairs_from_reinforced_andesite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_polished_andesite_stairs_from_reinforced_andesite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_andesite": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_andesite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_polished_andesite_stairs_from_reinforced_andesite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_andesite",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_polished_andesite_stairs_from_reinforced_polished_andesite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_polished_andesite_stairs_from_reinforced_polished_andesite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_polished_andesite_stairs_from_reinforced_polished_andesite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_polished_andesite": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_polished_andesite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_polished_andesite_stairs_from_reinforced_polished_andesite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_polished_andesite",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_polished_diorite_from_reinforced_diorite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_polished_diorite_from_reinforced_diorite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_polished_diorite_from_reinforced_diorite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_diorite": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_diorite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_polished_diorite_from_reinforced_diorite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_diorite",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_polished_diorite_slab_from_reinforced_diorite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_polished_diorite_slab_from_reinforced_diorite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_polished_diorite_slab_from_reinforced_diorite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_diorite": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_diorite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_polished_diorite_slab_from_reinforced_diorite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_diorite",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_polished_diorite_slab_from_reinforced_polished_diorite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_polished_diorite_slab_from_reinforced_polished_diorite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_polished_diorite_slab_from_reinforced_polished_diorite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_polished_diorite": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_polished_diorite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_polished_diorite_slab_from_reinforced_polished_diorite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_polished_diorite",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_polished_diorite_stairs_from_reinforced_diorite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_polished_diorite_stairs_from_reinforced_diorite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_polished_diorite_stairs_from_reinforced_diorite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_diorite": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_diorite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_polished_diorite_stairs_from_reinforced_diorite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_diorite",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_polished_diorite_stairs_from_reinforced_polished_diorite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_polished_diorite_stairs_from_reinforced_polished_diorite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_polished_diorite_stairs_from_reinforced_polished_diorite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_polished_diorite": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_polished_diorite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_polished_diorite_stairs_from_reinforced_polished_diorite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_polished_diorite",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_polished_granite_from_reinforced_granite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_polished_granite_from_reinforced_granite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_polished_granite_from_reinforced_granite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_granite": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_granite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_polished_granite_from_reinforced_granite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_granite",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_polished_granite_slab_from_reinforced_granite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_polished_granite_slab_from_reinforced_granite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_polished_granite_slab_from_reinforced_granite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_granite": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_granite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_polished_granite_slab_from_reinforced_granite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_granite",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_polished_granite_slab_from_reinforced_polished_granite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_polished_granite_slab_from_reinforced_polished_granite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_polished_granite_slab_from_reinforced_polished_granite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_polished_granite": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_polished_granite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_polished_granite_slab_from_reinforced_polished_granite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_polished_granite",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_polished_granite_stairs_from_reinforced_granite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_polished_granite_stairs_from_reinforced_granite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_polished_granite_stairs_from_reinforced_granite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_granite": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_granite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_polished_granite_stairs_from_reinforced_granite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_granite",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_polished_granite_stairs_from_reinforced_polished_granite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_polished_granite_stairs_from_reinforced_polished_granite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_polished_granite_stairs_from_reinforced_polished_granite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_polished_granite": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_polished_granite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_polished_granite_stairs_from_reinforced_polished_granite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_polished_granite",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_prismarine_brick_slab_from_reinforced_prismarine_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_prismarine_brick_slab_from_reinforced_prismarine_bricks_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_prismarine_brick_slab_from_reinforced_prismarine_bricks_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_prismarine_bricks": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_prismarine_bricks"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_prismarine_brick_slab_from_reinforced_prismarine_bricks_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_prismarine_bricks",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_prismarine_brick_stairs_from_reinforced_prismarine_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_prismarine_brick_stairs_from_reinforced_prismarine_bricks_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_prismarine_brick_stairs_from_reinforced_prismarine_bricks_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_prismarine_bricks": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_prismarine_bricks"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_prismarine_brick_stairs_from_reinforced_prismarine_bricks_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_prismarine_bricks",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_prismarine_slab_from_reinforced_prismarine_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_prismarine_slab_from_reinforced_prismarine_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_prismarine_slab_from_reinforced_prismarine_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_prismarine": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_prismarine"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_prismarine_slab_from_reinforced_prismarine_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_prismarine",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_prismarine_stairs_from_reinforced_prismarine_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_prismarine_stairs_from_reinforced_prismarine_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_prismarine_stairs_from_reinforced_prismarine_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_prismarine": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_prismarine"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_prismarine_stairs_from_reinforced_prismarine_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_prismarine",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_prismarine_wall_from_reinforced_prismarine_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_prismarine_wall_from_reinforced_prismarine_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_prismarine_wall_from_reinforced_prismarine_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_prismarine": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_prismarine"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_prismarine_wall_from_reinforced_prismarine_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_prismarine",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_purpur_pillar_from_reinforced_purpur_block_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_purpur_pillar_from_reinforced_purpur_block_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_purpur_pillar_from_reinforced_purpur_block_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_purpur_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_purpur_block"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_purpur_pillar_from_reinforced_purpur_block_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_purpur_block",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_purpur_slab_from_reinforced_purpur_block_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_purpur_slab_from_reinforced_purpur_block_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_purpur_slab_from_reinforced_purpur_block_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_purpur_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_purpur_block"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_purpur_slab_from_reinforced_purpur_block_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_purpur_block",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_purpur_stairs_from_reinforced_purpur_block_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_purpur_stairs_from_reinforced_purpur_block_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_purpur_stairs_from_reinforced_purpur_block_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_purpur_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_purpur_block"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_purpur_stairs_from_reinforced_purpur_block_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_purpur_block",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_quartz_pillar_from_reinforced_quartz_block_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_quartz_pillar_from_reinforced_quartz_block_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_quartz_pillar_from_reinforced_quartz_block_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_quartz_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_quartz_block"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_quartz_pillar_from_reinforced_quartz_block_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_quartz_block",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_quartz_slab_from_reinforced_quartz_block_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_quartz_slab_from_reinforced_quartz_block_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_quartz_slab_from_reinforced_quartz_block_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_quartz_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_quartz_block"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_quartz_slab_from_reinforced_quartz_block_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_quartz_block",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_quartz_stairs_from_reinforced_quartz_block_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_quartz_stairs_from_reinforced_quartz_block_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_quartz_stairs_from_reinforced_quartz_block_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_quartz_block": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_quartz_block"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_quartz_stairs_from_reinforced_quartz_block_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_quartz_block",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_red_nether_brick_slab_from_reinforced_red_nether_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_red_nether_brick_slab_from_reinforced_red_nether_bricks_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_red_nether_brick_slab_from_reinforced_red_nether_bricks_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_red_nether_bricks": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_red_nether_bricks"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_red_nether_brick_slab_from_reinforced_red_nether_bricks_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_red_nether_bricks",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_red_nether_brick_stairs_from_reinforced_red_nether_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_red_nether_brick_stairs_from_reinforced_red_nether_bricks_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_red_nether_brick_stairs_from_reinforced_red_nether_bricks_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_red_nether_bricks": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_red_nether_bricks"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_red_nether_brick_stairs_from_reinforced_red_nether_bricks_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_red_nether_bricks",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_red_nether_brick_wall_from_reinforced_red_nether_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_red_nether_brick_wall_from_reinforced_red_nether_bricks_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_red_nether_brick_wall_from_reinforced_red_nether_bricks_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_red_nether_bricks": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_red_nether_bricks"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_red_nether_brick_wall_from_reinforced_red_nether_bricks_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_red_nether_bricks",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_red_sandstone_slab_from_reinforced_red_sandstone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_red_sandstone_slab_from_reinforced_red_sandstone_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_red_sandstone_slab_from_reinforced_red_sandstone_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_red_sandstone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_red_sandstone"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_red_sandstone_slab_from_reinforced_red_sandstone_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_red_sandstone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_red_sandstone_stairs_from_reinforced_red_sandstone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_red_sandstone_stairs_from_reinforced_red_sandstone_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_red_sandstone_stairs_from_reinforced_red_sandstone_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_red_sandstone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_red_sandstone"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_red_sandstone_stairs_from_reinforced_red_sandstone_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_red_sandstone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_red_sandstone_wall_from_reinforced_red_sandstone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_red_sandstone_wall_from_reinforced_red_sandstone_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_red_sandstone_wall_from_reinforced_red_sandstone_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_red_sandstone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_red_sandstone"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_red_sandstone_wall_from_reinforced_red_sandstone_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_red_sandstone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_sandstone_slab_from_reinforced_sandstone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_sandstone_slab_from_reinforced_sandstone_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_sandstone_slab_from_reinforced_sandstone_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_sandstone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_sandstone"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_sandstone_slab_from_reinforced_sandstone_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_sandstone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_sandstone_stairs_from_reinforced_sandstone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_sandstone_stairs_from_reinforced_sandstone_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_sandstone_stairs_from_reinforced_sandstone_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_sandstone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_sandstone"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_sandstone_stairs_from_reinforced_sandstone_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_sandstone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_sandstone_wall_from_reinforced_sandstone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_sandstone_wall_from_reinforced_sandstone_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_sandstone_wall_from_reinforced_sandstone_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_sandstone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_sandstone"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_sandstone_wall_from_reinforced_sandstone_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_sandstone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_smooth_quartz_slab_from_reinforced_smooth_quartz_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_smooth_quartz_slab_from_reinforced_smooth_quartz_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_smooth_quartz_slab_from_reinforced_smooth_quartz_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_smooth_quartz": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_smooth_quartz"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_smooth_quartz_slab_from_reinforced_smooth_quartz_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_smooth_quartz",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_smooth_quartz_stairs_from_reinforced_smooth_quartz_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_smooth_quartz_stairs_from_reinforced_smooth_quartz_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_smooth_quartz_stairs_from_reinforced_smooth_quartz_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_smooth_quartz": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_smooth_quartz"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_smooth_quartz_stairs_from_reinforced_smooth_quartz_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_smooth_quartz",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_smooth_red_sandstone_slab_from_reinforced_smooth_red_sandstone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_smooth_red_sandstone_slab_from_reinforced_smooth_red_sandstone_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_smooth_red_sandstone_slab_from_reinforced_smooth_red_sandstone_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_smooth_red_sandstone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_smooth_red_sandstone"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_smooth_red_sandstone_slab_from_reinforced_smooth_red_sandstone_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_smooth_red_sandstone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_smooth_red_sandstone_stairs_from_reinforced_smooth_red_sandstone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_smooth_red_sandstone_stairs_from_reinforced_smooth_red_sandstone_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_smooth_red_sandstone_stairs_from_reinforced_smooth_red_sandstone_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_smooth_red_sandstone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_smooth_red_sandstone"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_smooth_red_sandstone_stairs_from_reinforced_smooth_red_sandstone_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_smooth_red_sandstone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_smooth_sandstone_slab_from_reinforced_smooth_sandstone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_smooth_sandstone_slab_from_reinforced_smooth_sandstone_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_smooth_sandstone_slab_from_reinforced_smooth_sandstone_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_smooth_sandstone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_smooth_sandstone"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_smooth_sandstone_slab_from_reinforced_smooth_sandstone_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_smooth_sandstone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_smooth_sandstone_stairs_from_reinforced_smooth_sandstone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_smooth_sandstone_stairs_from_reinforced_smooth_sandstone_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_smooth_sandstone_stairs_from_reinforced_smooth_sandstone_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_smooth_sandstone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_smooth_sandstone"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_smooth_sandstone_stairs_from_reinforced_smooth_sandstone_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_smooth_sandstone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_stone_brick_slab_from_reinforced_stone_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_stone_brick_slab_from_reinforced_stone_bricks_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_stone_brick_slab_from_reinforced_stone_bricks_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_stone_bricks": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_stone_bricks"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_stone_brick_slab_from_reinforced_stone_bricks_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_stone_bricks",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_stone_brick_slab_from_reinforced_stone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_stone_brick_slab_from_reinforced_stone_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_stone_brick_slab_from_reinforced_stone_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_stone"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_stone_brick_slab_from_reinforced_stone_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_stone_brick_stairs_from_reinforced_stone_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_stone_brick_stairs_from_reinforced_stone_bricks_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_stone_brick_stairs_from_reinforced_stone_bricks_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_stone_bricks": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_stone_bricks"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_stone_brick_stairs_from_reinforced_stone_bricks_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_stone_bricks",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_stone_brick_stairs_from_reinforced_stone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_stone_brick_stairs_from_reinforced_stone_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_stone_brick_stairs_from_reinforced_stone_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_stone"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_stone_brick_stairs_from_reinforced_stone_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_stone_brick_wall_from_reinforced_stone_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_stone_brick_wall_from_reinforced_stone_bricks_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_stone_brick_wall_from_reinforced_stone_bricks_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_stone_bricks": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_stone_bricks"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_stone_brick_wall_from_reinforced_stone_bricks_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_stone_bricks",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_stone_brick_wall_from_reinforced_stone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_stone_brick_wall_from_reinforced_stone_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_stone_brick_wall_from_reinforced_stone_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_stone"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_stone_brick_wall_from_reinforced_stone_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_stone_bricks_from_reinforced_stone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_stone_bricks_from_reinforced_stone_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_stone_bricks_from_reinforced_stone_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_stone"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_stone_bricks_from_reinforced_stone_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_stone_slab_from_reinforced_smooth_stone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_stone_slab_from_reinforced_smooth_stone_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_stone_slab_from_reinforced_smooth_stone_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_smooth_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_smooth_stone"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_stone_slab_from_reinforced_smooth_stone_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_smooth_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_stone_stairs_from_reinforced_stone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/advancements/recipes/securitycraft/reinforced_stone_stairs_from_reinforced_stone_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "securitycraft:reinforced_stone_stairs_from_reinforced_stone_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_reinforced_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "securitycraft:reinforced_stone"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "securitycraft:reinforced_stone_stairs_from_reinforced_stone_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_reinforced_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/securitycraft/recipes/chiseled_crystal_quartz_from_crystal_quartz_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/chiseled_crystal_quartz_from_crystal_quartz_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:crystal_quartz"
+  },
+  "result": "securitycraft:chiseled_crystal_quartz",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/crystal_quartz_pillar_from_crystal_quartz_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/crystal_quartz_pillar_from_crystal_quartz_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:crystal_quartz"
+  },
+  "result": "securitycraft:crystal_quartz_pillar",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/crystal_quartz_slab_from_crystal_quartz_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/crystal_quartz_slab_from_crystal_quartz_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:crystal_quartz"
+  },
+  "result": "securitycraft:crystal_quartz_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/securitycraft/recipes/crystal_quartz_stairs_from_crystal_quartz_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/crystal_quartz_stairs_from_crystal_quartz_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:crystal_quartz"
+  },
+  "result": "securitycraft:crystal_quartz_stairs",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_andesite_slab_from_reinforced_andesite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_andesite_slab_from_reinforced_andesite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_andesite"
+  },
+  "result": "securitycraft:reinforced_andesite_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_andesite_stairs_from_reinforced_andesite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_andesite_stairs_from_reinforced_andesite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_andesite"
+  },
+  "result": "securitycraft:reinforced_andesite_stairs",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_andesite_wall_from_reinforced_andesite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_andesite_wall_from_reinforced_andesite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_andesite"
+  },
+  "result": "securitycraft:reinforced_andesite_wall",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_brick_slab_from_reinforced_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_brick_slab_from_reinforced_bricks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_bricks"
+  },
+  "result": "securitycraft:reinforced_brick_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_brick_stairs_from_reinforced_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_brick_stairs_from_reinforced_bricks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_bricks"
+  },
+  "result": "securitycraft:reinforced_brick_stairs",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_brick_wall_from_reinforced_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_brick_wall_from_reinforced_bricks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_bricks"
+  },
+  "result": "securitycraft:reinforced_brick_wall",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_chiseled_crystal_quartz_block_from_reinforced_crystal_quartz_block_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_chiseled_crystal_quartz_block_from_reinforced_crystal_quartz_block_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_crystal_quartz_block"
+  },
+  "result": "securitycraft:reinforced_chiseled_crystal_quartz_block",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_chiseled_quartz_block_from_reinforced_quartz_block_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_chiseled_quartz_block_from_reinforced_quartz_block_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_quartz_block"
+  },
+  "result": "securitycraft:reinforced_chiseled_quartz_block",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_chiseled_red_sandstone_from_reinforced_red_sandstone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_chiseled_red_sandstone_from_reinforced_red_sandstone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_red_sandstone"
+  },
+  "result": "securitycraft:reinforced_chiseled_red_sandstone",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_chiseled_sandstone_from_reinforced_sandstone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_chiseled_sandstone_from_reinforced_sandstone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_sandstone"
+  },
+  "result": "securitycraft:reinforced_chiseled_sandstone",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_chiseled_stone_bricks_from_reinforced_stone_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_chiseled_stone_bricks_from_reinforced_stone_bricks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_stone_bricks"
+  },
+  "result": "securitycraft:reinforced_chiseled_stone_bricks",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_chiseled_stone_bricks_from_reinforced_stone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_chiseled_stone_bricks_from_reinforced_stone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_stone"
+  },
+  "result": "securitycraft:reinforced_chiseled_stone_bricks",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_cobblestone_slab_from_reinforced_cobblestone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_cobblestone_slab_from_reinforced_cobblestone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_cobblestone"
+  },
+  "result": "securitycraft:reinforced_cobblestone_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_cobblestone_stairs_from_reinforced_cobblestone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_cobblestone_stairs_from_reinforced_cobblestone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_cobblestone"
+  },
+  "result": "securitycraft:reinforced_cobblestone_stairs",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_cobblestone_wall_from_reinforced_cobblestone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_cobblestone_wall_from_reinforced_cobblestone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_cobblestone"
+  },
+  "result": "securitycraft:reinforced_cobblestone_wall",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_crystal_quartz_pillar_from_reinforced_crystal_quartz_block_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_crystal_quartz_pillar_from_reinforced_crystal_quartz_block_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_crystal_quartz_block"
+  },
+  "result": "securitycraft:reinforced_crystal_quartz_pillar",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_crystal_quartz_slab_from_reinforced_crystal_quartz_block_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_crystal_quartz_slab_from_reinforced_crystal_quartz_block_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_crystal_quartz_block"
+  },
+  "result": "securitycraft:reinforced_crystal_quartz_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_crystal_quartz_stairs_from_reinforced_crystal_quartz_block_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_crystal_quartz_stairs_from_reinforced_crystal_quartz_block_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_crystal_quartz_block"
+  },
+  "result": "securitycraft:reinforced_crystal_quartz_stairs",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_cut_red_sandstone_from_reinforced_red_sandstone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_cut_red_sandstone_from_reinforced_red_sandstone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_red_sandstone"
+  },
+  "result": "securitycraft:reinforced_cut_red_sandstone",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_cut_red_sandstone_slab_from_reinforced_cut_red_sandstone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_cut_red_sandstone_slab_from_reinforced_cut_red_sandstone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_cut_red_sandstone"
+  },
+  "result": "securitycraft:reinforced_cut_red_sandstone_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_cut_red_sandstone_slab_from_reinforced_red_sandstone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_cut_red_sandstone_slab_from_reinforced_red_sandstone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_red_sandstone"
+  },
+  "result": "securitycraft:reinforced_cut_red_sandstone_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_cut_sandstone_from_reinforced_sandstone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_cut_sandstone_from_reinforced_sandstone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_sandstone"
+  },
+  "result": "securitycraft:reinforced_cut_sandstone",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_cut_sandstone_slab_from_reinforced_cut_sandstone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_cut_sandstone_slab_from_reinforced_cut_sandstone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_cut_sandstone"
+  },
+  "result": "securitycraft:reinforced_cut_sandstone_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_cut_sandstone_slab_from_reinforced_sandstone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_cut_sandstone_slab_from_reinforced_sandstone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_sandstone"
+  },
+  "result": "securitycraft:reinforced_cut_sandstone_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_dark_prismarine_slab_from_reinforced_dark_prismarine_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_dark_prismarine_slab_from_reinforced_dark_prismarine_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_dark_prismarine"
+  },
+  "result": "securitycraft:reinforced_dark_prismarine_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_dark_prismarine_stairs_from_reinforced_dark_prismarine_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_dark_prismarine_stairs_from_reinforced_dark_prismarine_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_dark_prismarine"
+  },
+  "result": "securitycraft:reinforced_dark_prismarine_stairs",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_diorite_slab_from_reinforced_diorite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_diorite_slab_from_reinforced_diorite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_diorite"
+  },
+  "result": "securitycraft:reinforced_diorite_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_diorite_stairs_from_reinforced_diorite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_diorite_stairs_from_reinforced_diorite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_diorite"
+  },
+  "result": "securitycraft:reinforced_diorite_stairs",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_diorite_wall_from_reinforced_diorite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_diorite_wall_from_reinforced_diorite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_diorite"
+  },
+  "result": "securitycraft:reinforced_diorite_wall",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_end_stone_brick_slab_from_reinforced_end_stone_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_end_stone_brick_slab_from_reinforced_end_stone_bricks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_end_stone_bricks"
+  },
+  "result": "securitycraft:reinforced_end_stone_brick_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_end_stone_brick_slab_from_reinforced_end_stone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_end_stone_brick_slab_from_reinforced_end_stone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_end_stone"
+  },
+  "result": "securitycraft:reinforced_end_stone_brick_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_end_stone_brick_stairs_from_reinforced_end_stone_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_end_stone_brick_stairs_from_reinforced_end_stone_bricks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_end_stone_bricks"
+  },
+  "result": "securitycraft:reinforced_end_stone_brick_stairs",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_end_stone_brick_stairs_from_reinforced_end_stone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_end_stone_brick_stairs_from_reinforced_end_stone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_end_stone"
+  },
+  "result": "securitycraft:reinforced_end_stone_brick_stairs",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_end_stone_brick_wall_from_reinforced_end_stone_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_end_stone_brick_wall_from_reinforced_end_stone_bricks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_end_stone_bricks"
+  },
+  "result": "securitycraft:reinforced_end_stone_brick_wall",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_end_stone_brick_wall_from_reinforced_end_stone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_end_stone_brick_wall_from_reinforced_end_stone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_end_stone"
+  },
+  "result": "securitycraft:reinforced_end_stone_brick_wall",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_end_stone_bricks_from_reinforced_end_stone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_end_stone_bricks_from_reinforced_end_stone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_end_stone"
+  },
+  "result": "securitycraft:reinforced_end_stone_bricks",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_glass.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_glass.json
@@ -1,7 +1,7 @@
 {
   "type": "minecraft:smelting",
   "ingredient": {
-    "item": "securitycraft:reinforced_sand"
+    "tag": "securitycraft:reinforced/sand"
   },
   "result": "securitycraft:reinforced_glass",
   "experience": 0.1,

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_granite_slab_from_reinforced_granite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_granite_slab_from_reinforced_granite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_granite"
+  },
+  "result": "securitycraft:reinforced_granite_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_granite_stairs_from_reinforced_granite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_granite_stairs_from_reinforced_granite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_granite"
+  },
+  "result": "securitycraft:reinforced_granite_stairs",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_granite_wall_from_reinforced_granite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_granite_wall_from_reinforced_granite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_granite"
+  },
+  "result": "securitycraft:reinforced_granite_wall",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_mossy_cobblestone_slab_from_reinforced_mossy_cobblestone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_mossy_cobblestone_slab_from_reinforced_mossy_cobblestone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_mossy_cobblestone"
+  },
+  "result": "securitycraft:reinforced_mossy_cobblestone_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_mossy_cobblestone_stairs_from_reinforced_mossy_cobblestone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_mossy_cobblestone_stairs_from_reinforced_mossy_cobblestone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_mossy_cobblestone"
+  },
+  "result": "securitycraft:reinforced_mossy_cobblestone_stairs",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_mossy_cobblestone_wall_from_reinforced_mossy_cobblestone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_mossy_cobblestone_wall_from_reinforced_mossy_cobblestone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_mossy_cobblestone"
+  },
+  "result": "securitycraft:reinforced_mossy_cobblestone_wall",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_mossy_stone_brick_slab_from_reinforced_mossy_stone_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_mossy_stone_brick_slab_from_reinforced_mossy_stone_bricks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_mossy_stone_bricks"
+  },
+  "result": "securitycraft:reinforced_mossy_stone_brick_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_mossy_stone_brick_stairs_from_reinforced_mossy_stone_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_mossy_stone_brick_stairs_from_reinforced_mossy_stone_bricks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_mossy_stone_bricks"
+  },
+  "result": "securitycraft:reinforced_mossy_stone_brick_stairs",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_mossy_stone_brick_wall_from_reinforced_mossy_stone_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_mossy_stone_brick_wall_from_reinforced_mossy_stone_bricks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_mossy_stone_bricks"
+  },
+  "result": "securitycraft:reinforced_mossy_stone_brick_wall",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_nether_brick_slab_from_reinforced_nether_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_nether_brick_slab_from_reinforced_nether_bricks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_nether_bricks"
+  },
+  "result": "securitycraft:reinforced_nether_brick_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_nether_brick_stairs_from_reinforced_nether_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_nether_brick_stairs_from_reinforced_nether_bricks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_nether_bricks"
+  },
+  "result": "securitycraft:reinforced_nether_brick_stairs",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_nether_brick_wall_from_reinforced_nether_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_nether_brick_wall_from_reinforced_nether_bricks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_nether_bricks"
+  },
+  "result": "securitycraft:reinforced_nether_brick_wall",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_normal_stone_slab_from_reinforced_stone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_normal_stone_slab_from_reinforced_stone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_stone"
+  },
+  "result": "securitycraft:reinforced_normal_stone_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_polished_andesite_from_reinforced_andesite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_polished_andesite_from_reinforced_andesite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_andesite"
+  },
+  "result": "securitycraft:reinforced_polished_andesite",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_polished_andesite_slab_from_reinforced_andesite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_polished_andesite_slab_from_reinforced_andesite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_andesite"
+  },
+  "result": "securitycraft:reinforced_polished_andesite_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_polished_andesite_slab_from_reinforced_polished_andesite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_polished_andesite_slab_from_reinforced_polished_andesite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_polished_andesite"
+  },
+  "result": "securitycraft:reinforced_polished_andesite_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_polished_andesite_stairs_from_reinforced_andesite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_polished_andesite_stairs_from_reinforced_andesite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_andesite"
+  },
+  "result": "securitycraft:reinforced_polished_andesite_stairs",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_polished_andesite_stairs_from_reinforced_polished_andesite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_polished_andesite_stairs_from_reinforced_polished_andesite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_polished_andesite"
+  },
+  "result": "securitycraft:reinforced_polished_andesite_stairs",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_polished_diorite_from_reinforced_diorite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_polished_diorite_from_reinforced_diorite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_diorite"
+  },
+  "result": "securitycraft:reinforced_polished_diorite",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_polished_diorite_slab_from_reinforced_diorite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_polished_diorite_slab_from_reinforced_diorite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_diorite"
+  },
+  "result": "securitycraft:reinforced_polished_diorite_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_polished_diorite_slab_from_reinforced_polished_diorite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_polished_diorite_slab_from_reinforced_polished_diorite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_polished_diorite"
+  },
+  "result": "securitycraft:reinforced_polished_diorite_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_polished_diorite_stairs_from_reinforced_diorite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_polished_diorite_stairs_from_reinforced_diorite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_diorite"
+  },
+  "result": "securitycraft:reinforced_polished_diorite_stairs",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_polished_diorite_stairs_from_reinforced_polished_diorite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_polished_diorite_stairs_from_reinforced_polished_diorite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_polished_diorite"
+  },
+  "result": "securitycraft:reinforced_polished_diorite_stairs",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_polished_granite_from_reinforced_granite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_polished_granite_from_reinforced_granite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_granite"
+  },
+  "result": "securitycraft:reinforced_polished_granite",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_polished_granite_slab_from_reinforced_granite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_polished_granite_slab_from_reinforced_granite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_granite"
+  },
+  "result": "securitycraft:reinforced_polished_granite_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_polished_granite_slab_from_reinforced_polished_granite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_polished_granite_slab_from_reinforced_polished_granite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_polished_granite"
+  },
+  "result": "securitycraft:reinforced_polished_granite_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_polished_granite_stairs_from_reinforced_granite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_polished_granite_stairs_from_reinforced_granite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_granite"
+  },
+  "result": "securitycraft:reinforced_polished_granite_stairs",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_polished_granite_stairs_from_reinforced_polished_granite_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_polished_granite_stairs_from_reinforced_polished_granite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_polished_granite"
+  },
+  "result": "securitycraft:reinforced_polished_granite_stairs",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_prismarine_brick_slab_from_reinforced_prismarine_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_prismarine_brick_slab_from_reinforced_prismarine_bricks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_prismarine_bricks"
+  },
+  "result": "securitycraft:reinforced_prismarine_brick_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_prismarine_brick_stairs_from_reinforced_prismarine_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_prismarine_brick_stairs_from_reinforced_prismarine_bricks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_prismarine_bricks"
+  },
+  "result": "securitycraft:reinforced_prismarine_brick_stairs",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_prismarine_slab_from_reinforced_prismarine_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_prismarine_slab_from_reinforced_prismarine_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_prismarine"
+  },
+  "result": "securitycraft:reinforced_prismarine_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_prismarine_stairs_from_reinforced_prismarine_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_prismarine_stairs_from_reinforced_prismarine_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_prismarine"
+  },
+  "result": "securitycraft:reinforced_prismarine_stairs",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_prismarine_wall_from_reinforced_prismarine_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_prismarine_wall_from_reinforced_prismarine_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_prismarine"
+  },
+  "result": "securitycraft:reinforced_prismarine_wall",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_purpur_pillar_from_reinforced_purpur_block_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_purpur_pillar_from_reinforced_purpur_block_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_purpur_block"
+  },
+  "result": "securitycraft:reinforced_purpur_pillar",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_purpur_slab_from_reinforced_purpur_block_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_purpur_slab_from_reinforced_purpur_block_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_purpur_block"
+  },
+  "result": "securitycraft:reinforced_purpur_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_purpur_stairs_from_reinforced_purpur_block_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_purpur_stairs_from_reinforced_purpur_block_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_purpur_block"
+  },
+  "result": "securitycraft:reinforced_purpur_stairs",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_quartz_pillar_from_reinforced_quartz_block_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_quartz_pillar_from_reinforced_quartz_block_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_quartz_block"
+  },
+  "result": "securitycraft:reinforced_quartz_pillar",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_quartz_slab_from_reinforced_quartz_block_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_quartz_slab_from_reinforced_quartz_block_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_quartz_block"
+  },
+  "result": "securitycraft:reinforced_quartz_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_quartz_stairs_from_reinforced_quartz_block_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_quartz_stairs_from_reinforced_quartz_block_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_quartz_block"
+  },
+  "result": "securitycraft:reinforced_quartz_stairs",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_red_nether_brick_slab_from_reinforced_red_nether_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_red_nether_brick_slab_from_reinforced_red_nether_bricks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_red_nether_bricks"
+  },
+  "result": "securitycraft:reinforced_red_nether_brick_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_red_nether_brick_stairs_from_reinforced_red_nether_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_red_nether_brick_stairs_from_reinforced_red_nether_bricks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_red_nether_bricks"
+  },
+  "result": "securitycraft:reinforced_red_nether_brick_stairs",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_red_nether_brick_wall_from_reinforced_red_nether_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_red_nether_brick_wall_from_reinforced_red_nether_bricks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_red_nether_bricks"
+  },
+  "result": "securitycraft:reinforced_red_nether_brick_wall",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_red_sandstone_slab_from_reinforced_red_sandstone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_red_sandstone_slab_from_reinforced_red_sandstone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_red_sandstone"
+  },
+  "result": "securitycraft:reinforced_red_sandstone_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_red_sandstone_stairs_from_reinforced_red_sandstone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_red_sandstone_stairs_from_reinforced_red_sandstone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_red_sandstone"
+  },
+  "result": "securitycraft:reinforced_red_sandstone_stairs",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_red_sandstone_wall_from_reinforced_red_sandstone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_red_sandstone_wall_from_reinforced_red_sandstone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_red_sandstone"
+  },
+  "result": "securitycraft:reinforced_red_sandstone_wall",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_sandstone_slab_from_reinforced_sandstone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_sandstone_slab_from_reinforced_sandstone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_sandstone"
+  },
+  "result": "securitycraft:reinforced_sandstone_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_sandstone_stairs_from_reinforced_sandstone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_sandstone_stairs_from_reinforced_sandstone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_sandstone"
+  },
+  "result": "securitycraft:reinforced_sandstone_stairs",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_sandstone_wall_from_reinforced_sandstone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_sandstone_wall_from_reinforced_sandstone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_sandstone"
+  },
+  "result": "securitycraft:reinforced_sandstone_wall",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_smooth_quartz_slab_from_reinforced_smooth_quartz_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_smooth_quartz_slab_from_reinforced_smooth_quartz_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_smooth_quartz"
+  },
+  "result": "securitycraft:reinforced_smooth_quartz_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_smooth_quartz_stairs_from_reinforced_smooth_quartz_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_smooth_quartz_stairs_from_reinforced_smooth_quartz_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_smooth_quartz"
+  },
+  "result": "securitycraft:reinforced_smooth_quartz_stairs",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_smooth_red_sandstone_slab_from_reinforced_smooth_red_sandstone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_smooth_red_sandstone_slab_from_reinforced_smooth_red_sandstone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_smooth_red_sandstone"
+  },
+  "result": "securitycraft:reinforced_smooth_red_sandstone_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_smooth_red_sandstone_stairs_from_reinforced_smooth_red_sandstone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_smooth_red_sandstone_stairs_from_reinforced_smooth_red_sandstone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_smooth_red_sandstone"
+  },
+  "result": "securitycraft:reinforced_smooth_red_sandstone_stairs",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_smooth_sandstone_slab_from_reinforced_smooth_sandstone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_smooth_sandstone_slab_from_reinforced_smooth_sandstone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_smooth_sandstone"
+  },
+  "result": "securitycraft:reinforced_smooth_sandstone_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_smooth_sandstone_stairs_from_reinforced_smooth_sandstone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_smooth_sandstone_stairs_from_reinforced_smooth_sandstone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_smooth_sandstone"
+  },
+  "result": "securitycraft:reinforced_smooth_sandstone_stairs",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_stone_brick_slab_from_reinforced_stone_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_stone_brick_slab_from_reinforced_stone_bricks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_stone_bricks"
+  },
+  "result": "securitycraft:reinforced_stone_brick_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_stone_brick_slab_from_reinforced_stone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_stone_brick_slab_from_reinforced_stone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_stone"
+  },
+  "result": "securitycraft:reinforced_stone_brick_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_stone_brick_stairs_from_reinforced_stone_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_stone_brick_stairs_from_reinforced_stone_bricks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_stone_bricks"
+  },
+  "result": "securitycraft:reinforced_stone_brick_stairs",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_stone_brick_stairs_from_reinforced_stone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_stone_brick_stairs_from_reinforced_stone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_stone"
+  },
+  "result": "securitycraft:reinforced_stone_brick_stairs",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_stone_brick_wall_from_reinforced_stone_bricks_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_stone_brick_wall_from_reinforced_stone_bricks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_stone_bricks"
+  },
+  "result": "securitycraft:reinforced_stone_brick_wall",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_stone_brick_wall_from_reinforced_stone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_stone_brick_wall_from_reinforced_stone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_stone"
+  },
+  "result": "securitycraft:reinforced_stone_brick_wall",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_stone_bricks_from_reinforced_stone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_stone_bricks_from_reinforced_stone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_stone"
+  },
+  "result": "securitycraft:reinforced_stone_bricks",
+  "count": 1
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_stone_slab_from_reinforced_smooth_stone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_stone_slab_from_reinforced_smooth_stone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_smooth_stone"
+  },
+  "result": "securitycraft:reinforced_stone_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_stone_stairs_from_reinforced_stone_stonecutting.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_stone_stairs_from_reinforced_stone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "securitycraft:reinforced_stone"
+  },
+  "result": "securitycraft:reinforced_stone_stairs",
+  "count": 1
+}

--- a/src/main/java/net/geforcemods/securitycraft/datagen/RecipeGenerator.java
+++ b/src/main/java/net/geforcemods/securitycraft/datagen/RecipeGenerator.java
@@ -922,7 +922,6 @@ public class RecipeGenerator extends RecipeProvider
 		addStonecuttingRecipe(consumer, SCContent.REINFORCED_CRYSTAL_QUARTZ.get(), SCContent.REINFORCED_CRYSTAL_QUARTZ_STAIRS.get(), 1);
 		addStonecuttingRecipe(consumer, SCContent.REINFORCED_CRYSTAL_QUARTZ.get(), SCContent.REINFORCED_CHISELED_CRYSTAL_QUARTZ.get(), 1);
 		addStonecuttingRecipe(consumer, SCContent.REINFORCED_CRYSTAL_QUARTZ.get(), SCContent.REINFORCED_CRYSTAL_QUARTZ_PILLAR.get(), 1);
-
 		addStonecuttingRecipe(consumer, SCContent.CRYSTAL_QUARTZ.get(), SCContent.CRYSTAL_QUARTZ_SLAB.get(), 2);
 		addStonecuttingRecipe(consumer, SCContent.CRYSTAL_QUARTZ.get(), SCContent.STAIRS_CRYSTAL_QUARTZ.get(), 1);
 		addStonecuttingRecipe(consumer, SCContent.CRYSTAL_QUARTZ.get(), SCContent.CHISELED_CRYSTAL_QUARTZ.get(), 1);
@@ -1212,8 +1211,9 @@ public class RecipeGenerator extends RecipeProvider
 	{
 		SingleItemRecipeBuilder.stonecuttingRecipe(Ingredient.fromItems(ingredient), result, count)
 		.addCriterion("has_" + ingredient.asItem().getRegistryName().getPath(), hasItem(ingredient))
-		.build(consumer, result.asItem().getRegistryName()+"_from_"+ingredient.asItem().getRegistryName().getPath()+"_stonecutting");
+		.build(consumer, result.asItem().getRegistryName() + "_from_" + ingredient.asItem().getRegistryName().getPath() + "_stonecutting");
 	}
+
 	@Override
 	public String getName()
 	{

--- a/src/main/java/net/geforcemods/securitycraft/datagen/RecipeGenerator.java
+++ b/src/main/java/net/geforcemods/securitycraft/datagen/RecipeGenerator.java
@@ -26,6 +26,7 @@ import net.minecraft.data.IFinishedRecipe;
 import net.minecraft.data.RecipeProvider;
 import net.minecraft.data.ShapedRecipeBuilder;
 import net.minecraft.data.ShapelessRecipeBuilder;
+import net.minecraft.data.SingleItemRecipeBuilder;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
@@ -805,7 +806,7 @@ public class RecipeGenerator extends RecipeProvider
 		CookingRecipeBuilder.smeltingRecipe(Ingredient.fromItems(SCContent.REINFORCED_RED_SANDSTONE.get()), SCContent.REINFORCED_SMOOTH_RED_SANDSTONE.get(), 0.1F, 200)
 		.addCriterion("has_reinforced_red_sandstone", hasItem(SCContent.REINFORCED_RED_SANDSTONE.get()))
 		.build(consumer);
-		CookingRecipeBuilder.smeltingRecipe(Ingredient.fromItems(SCContent.REINFORCED_SAND.get()), SCContent.REINFORCED_GLASS.get(), 0.1F, 200)
+		CookingRecipeBuilder.smeltingRecipe(Ingredient.fromTag(SCTags.Items.REINFORCED_SAND), SCContent.REINFORCED_GLASS.get(), 0.1F, 200)
 		.addCriterion("has_reinforced_sand", hasItem(SCContent.REINFORCED_SAND.get()))
 		.build(consumer);
 		CookingRecipeBuilder.smeltingRecipe(Ingredient.fromItems(SCContent.REINFORCED_SANDSTONE.get()), SCContent.REINFORCED_SMOOTH_SANDSTONE.get(), 0.1F, 200)
@@ -820,6 +821,112 @@ public class RecipeGenerator extends RecipeProvider
 		CookingRecipeBuilder.smeltingRecipe(Ingredient.fromItems(SCContent.REINFORCED_CLAY.get()), SCContent.REINFORCED_TERRACOTTA.get(), 0.35F, 200)
 		.addCriterion("has_reinforced_clay", hasItem(SCContent.REINFORCED_CLAY.get()))
 		.build(consumer);
+
+		//stonecutter recipes (ordered by the ingredient's sort in creative building tab)
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_STONE.get(), SCContent.REINFORCED_CHISELED_STONE_BRICKS.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_STONE.get(), SCContent.REINFORCED_STONE_BRICK_SLAB.get(), 2);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_STONE.get(), SCContent.REINFORCED_STONE_BRICK_STAIRS.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_STONE.get(), SCContent.REINFORCED_STONE_BRICK_WALL.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_STONE.get(), SCContent.REINFORCED_STONE_BRICKS.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_STONE.get(), SCContent.REINFORCED_NORMAL_STONE_SLAB.get(), 2);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_STONE.get(), SCContent.REINFORCED_STONE_STAIRS.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_SMOOTH_STONE.get(), SCContent.REINFORCED_SMOOTH_STONE_SLAB.get(), 2);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_STONE_BRICKS.get(), SCContent.REINFORCED_CHISELED_STONE_BRICKS.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_STONE_BRICKS.get(), SCContent.REINFORCED_STONE_BRICK_SLAB.get(), 2);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_STONE_BRICKS.get(), SCContent.REINFORCED_STONE_BRICK_STAIRS.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_STONE_BRICKS.get(), SCContent.REINFORCED_STONE_BRICK_WALL.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_MOSSY_STONE_BRICKS.get(), SCContent.REINFORCED_MOSSY_STONE_BRICK_SLAB.get(), 2);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_MOSSY_STONE_BRICKS.get(), SCContent.REINFORCED_MOSSY_STONE_BRICK_STAIRS.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_MOSSY_STONE_BRICKS.get(), SCContent.REINFORCED_MOSSY_STONE_BRICK_WALL.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_GRANITE.get(), SCContent.REINFORCED_GRANITE_SLAB.get(), 2);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_GRANITE.get(), SCContent.REINFORCED_GRANITE_STAIRS.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_GRANITE.get(), SCContent.REINFORCED_GRANITE_WALL.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_GRANITE.get(), SCContent.REINFORCED_POLISHED_GRANITE.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_GRANITE.get(), SCContent.REINFORCED_POLISHED_GRANITE_SLAB.get(), 2);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_GRANITE.get(), SCContent.REINFORCED_POLISHED_GRANITE_STAIRS.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_POLISHED_GRANITE.get(), SCContent.REINFORCED_POLISHED_GRANITE_SLAB.get(), 2);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_POLISHED_GRANITE.get(), SCContent.REINFORCED_POLISHED_GRANITE_STAIRS.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_DIORITE.get(), SCContent.REINFORCED_DIORITE_SLAB.get(), 2);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_DIORITE.get(), SCContent.REINFORCED_DIORITE_STAIRS.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_DIORITE.get(), SCContent.REINFORCED_DIORITE_WALL.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_DIORITE.get(), SCContent.REINFORCED_POLISHED_DIORITE.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_DIORITE.get(), SCContent.REINFORCED_POLISHED_DIORITE_SLAB.get(), 2);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_DIORITE.get(), SCContent.REINFORCED_POLISHED_DIORITE_STAIRS.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_POLISHED_DIORITE.get(), SCContent.REINFORCED_POLISHED_DIORITE_SLAB.get(), 2);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_POLISHED_DIORITE.get(), SCContent.REINFORCED_POLISHED_DIORITE_STAIRS.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_ANDESITE.get(), SCContent.REINFORCED_ANDESITE_SLAB.get(), 2);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_ANDESITE.get(), SCContent.REINFORCED_ANDESITE_STAIRS.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_ANDESITE.get(), SCContent.REINFORCED_ANDESITE_WALL.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_ANDESITE.get(), SCContent.REINFORCED_POLISHED_ANDESITE.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_ANDESITE.get(), SCContent.REINFORCED_POLISHED_ANDESITE_SLAB.get(), 2);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_ANDESITE.get(), SCContent.REINFORCED_POLISHED_ANDESITE_STAIRS.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_POLISHED_ANDESITE.get(), SCContent.REINFORCED_POLISHED_ANDESITE_SLAB.get(), 2);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_POLISHED_ANDESITE.get(), SCContent.REINFORCED_POLISHED_ANDESITE_STAIRS.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_COBBLESTONE.get(), SCContent.REINFORCED_COBBLESTONE_SLAB.get(), 2);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_COBBLESTONE.get(), SCContent.REINFORCED_COBBLESTONE_STAIRS.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_COBBLESTONE.get(), SCContent.REINFORCED_COBBLESTONE_WALL.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_MOSSY_COBBLESTONE.get(), SCContent.REINFORCED_MOSSY_COBBLESTONE_SLAB.get(), 2);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_MOSSY_COBBLESTONE.get(), SCContent.REINFORCED_MOSSY_COBBLESTONE_STAIRS.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_MOSSY_COBBLESTONE.get(), SCContent.REINFORCED_MOSSY_COBBLESTONE_WALL.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_SANDSTONE.get(), SCContent.REINFORCED_SANDSTONE_SLAB.get(), 2);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_SANDSTONE.get(), SCContent.REINFORCED_SANDSTONE_STAIRS.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_SANDSTONE.get(), SCContent.REINFORCED_SANDSTONE_WALL.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_SANDSTONE.get(), SCContent.REINFORCED_CUT_SANDSTONE.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_SANDSTONE.get(), SCContent.REINFORCED_CUT_SANDSTONE_SLAB.get(), 2);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_SANDSTONE.get(), SCContent.REINFORCED_CHISELED_SANDSTONE.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_CUT_SANDSTONE.get(), SCContent.REINFORCED_CUT_SANDSTONE_SLAB.get(), 2);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_SMOOTH_SANDSTONE.get(), SCContent.REINFORCED_SMOOTH_SANDSTONE_SLAB.get(), 2);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_SMOOTH_SANDSTONE.get(), SCContent.REINFORCED_SMOOTH_SANDSTONE_STAIRS.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_RED_SANDSTONE.get(), SCContent.REINFORCED_RED_SANDSTONE_SLAB.get(), 2);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_RED_SANDSTONE.get(), SCContent.REINFORCED_RED_SANDSTONE_STAIRS.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_RED_SANDSTONE.get(), SCContent.REINFORCED_RED_SANDSTONE_WALL.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_RED_SANDSTONE.get(), SCContent.REINFORCED_CUT_RED_SANDSTONE.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_RED_SANDSTONE.get(), SCContent.REINFORCED_CUT_RED_SANDSTONE_SLAB.get(), 2);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_RED_SANDSTONE.get(), SCContent.REINFORCED_CHISELED_RED_SANDSTONE.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_CUT_RED_SANDSTONE.get(), SCContent.REINFORCED_CUT_RED_SANDSTONE_SLAB.get(), 2);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_SMOOTH_RED_SANDSTONE.get(), SCContent.REINFORCED_SMOOTH_RED_SANDSTONE_SLAB.get(), 2);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_SMOOTH_RED_SANDSTONE.get(), SCContent.REINFORCED_SMOOTH_RED_SANDSTONE_STAIRS.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_PRISMARINE.get(), SCContent.REINFORCED_PRISMARINE_SLAB.get(), 2);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_PRISMARINE.get(), SCContent.REINFORCED_PRISMARINE_STAIRS.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_PRISMARINE.get(), SCContent.REINFORCED_PRISMARINE_WALL.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_PRISMARINE_BRICKS.get(), SCContent.REINFORCED_PRISMARINE_BRICK_SLAB.get(), 2);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_PRISMARINE_BRICKS.get(), SCContent.REINFORCED_PRISMARINE_BRICK_STAIRS.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_DARK_PRISMARINE.get(), SCContent.REINFORCED_DARK_PRISMARINE_SLAB.get(), 2);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_DARK_PRISMARINE.get(), SCContent.REINFORCED_DARK_PRISMARINE_STAIRS.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_QUARTZ.get(), SCContent.REINFORCED_QUARTZ_SLAB.get(), 2);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_QUARTZ.get(), SCContent.REINFORCED_QUARTZ_STAIRS.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_QUARTZ.get(), SCContent.REINFORCED_CHISELED_QUARTZ.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_QUARTZ.get(), SCContent.REINFORCED_QUARTZ_PILLAR.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_SMOOTH_QUARTZ.get(), SCContent.REINFORCED_SMOOTH_QUARTZ_SLAB.get(), 2);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_SMOOTH_QUARTZ.get(), SCContent.REINFORCED_SMOOTH_QUARTZ_STAIRS.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_PURPUR_BLOCK.get(), SCContent.REINFORCED_PURPUR_SLAB.get(), 2);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_PURPUR_BLOCK.get(), SCContent.REINFORCED_PURPUR_STAIRS.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_PURPUR_BLOCK.get(), SCContent.REINFORCED_PURPUR_PILLAR.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_BRICKS.get(), SCContent.REINFORCED_BRICK_SLAB.get(), 2);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_BRICKS.get(), SCContent.REINFORCED_BRICK_STAIRS.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_BRICKS.get(), SCContent.REINFORCED_BRICK_WALL.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_NETHER_BRICKS.get(), SCContent.REINFORCED_NETHER_BRICK_SLAB.get(), 2);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_NETHER_BRICKS.get(), SCContent.REINFORCED_NETHER_BRICK_STAIRS.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_NETHER_BRICKS.get(), SCContent.REINFORCED_NETHER_BRICK_WALL.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_RED_NETHER_BRICKS.get(), SCContent.REINFORCED_RED_NETHER_BRICK_SLAB.get(), 2);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_RED_NETHER_BRICKS.get(), SCContent.REINFORCED_RED_NETHER_BRICK_STAIRS.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_RED_NETHER_BRICKS.get(), SCContent.REINFORCED_RED_NETHER_BRICK_WALL.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_END_STONE.get(), SCContent.REINFORCED_END_STONE_BRICKS.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_END_STONE.get(), SCContent.REINFORCED_END_STONE_BRICK_SLAB.get(), 2);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_END_STONE.get(), SCContent.REINFORCED_END_STONE_BRICK_STAIRS.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_END_STONE.get(), SCContent.REINFORCED_END_STONE_BRICK_WALL.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_END_STONE_BRICKS.get(), SCContent.REINFORCED_END_STONE_BRICK_SLAB.get(), 2);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_END_STONE_BRICKS.get(), SCContent.REINFORCED_END_STONE_BRICK_STAIRS.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_END_STONE_BRICKS.get(), SCContent.REINFORCED_END_STONE_BRICK_WALL.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_CRYSTAL_QUARTZ.get(), SCContent.REINFORCED_CRYSTAL_QUARTZ_SLAB.get(), 2);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_CRYSTAL_QUARTZ.get(), SCContent.REINFORCED_CRYSTAL_QUARTZ_STAIRS.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_CRYSTAL_QUARTZ.get(), SCContent.REINFORCED_CHISELED_CRYSTAL_QUARTZ.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.REINFORCED_CRYSTAL_QUARTZ.get(), SCContent.REINFORCED_CRYSTAL_QUARTZ_PILLAR.get(), 1);
+
+		addStonecuttingRecipe(consumer, SCContent.CRYSTAL_QUARTZ.get(), SCContent.CRYSTAL_QUARTZ_SLAB.get(), 2);
+		addStonecuttingRecipe(consumer, SCContent.CRYSTAL_QUARTZ.get(), SCContent.STAIRS_CRYSTAL_QUARTZ.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.CRYSTAL_QUARTZ.get(), SCContent.CHISELED_CRYSTAL_QUARTZ.get(), 1);
+		addStonecuttingRecipe(consumer, SCContent.CRYSTAL_QUARTZ.get(), SCContent.CRYSTAL_QUARTZ_PILLAR.get(), 1);
 	}
 
 	protected final void addBarkRecipe(Consumer<IFinishedRecipe> consumer, IItemProvider log, IItemProvider result) //woof
@@ -1101,6 +1208,12 @@ public class RecipeGenerator extends RecipeProvider
 		.build(consumer);
 	}
 
+	protected final void addStonecuttingRecipe(Consumer<IFinishedRecipe> consumer, IItemProvider ingredient, IItemProvider result, int count)
+	{
+		SingleItemRecipeBuilder.stonecuttingRecipe(Ingredient.fromItems(ingredient), result, count)
+		.addCriterion("has_" + ingredient.asItem().getRegistryName().getPath(), hasItem(ingredient))
+		.build(consumer, result.asItem().getRegistryName()+"_from_"+ingredient.asItem().getRegistryName().getPath()+"_stonecutting");
+	}
 	@Override
 	public String getName()
 	{


### PR DESCRIPTION
In this PR I've created the stonecutting recipes of some reinforced blocks for parity with Vanilla Minecraft. (yeah there are a heck of a lot of them).
I've also upgraded the JEI version in build.gradle and adjusted the reinforced_glass smelting recipe to also include red sand.