### PR TITLE
Port the Secret Sign to 1.16

### DIFF
--- a/src/main/java/net/geforcemods/securitycraft/items/AdminToolItem.java
+++ b/src/main/java/net/geforcemods/securitycraft/items/AdminToolItem.java
@@ -20,6 +20,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ActionResultType;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.IFormattableTextComponent;
+import net.minecraft.util.text.ITextProperties;
 import net.minecraft.util.text.StringTextComponent;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.util.text.TranslationTextComponent;
@@ -73,7 +74,10 @@ public class AdminToolItem extends Item {
 
 					for(int i = 0; i < 4; i++)
 					{
-						PlayerUtils.sendMessageToPlayer(player, adminToolName, ((SecretSignTileEntity)te).signText[i].func_230532_e_(), TextFormatting.DARK_PURPLE); //TODO: is this signText conversion correct?
+						ITextProperties text = ((SecretSignTileEntity)te).func_235677_a_(i, tc -> tc);
+
+						if(text instanceof IFormattableTextComponent)
+							PlayerUtils.sendMessageToPlayer(player, adminToolName, (IFormattableTextComponent)text, TextFormatting.DARK_PURPLE);
 					}
 
 					hasInfo = true;

--- a/src/main/java/net/geforcemods/securitycraft/renderers/SecretSignTileEntityRenderer.java
+++ b/src/main/java/net/geforcemods/securitycraft/renderers/SecretSignTileEntityRenderer.java
@@ -21,6 +21,8 @@ import net.minecraft.client.renderer.tileentity.TileEntityRenderer;
 import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.util.math.vector.Vector3f;
 import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.ITextProperties;
+import net.minecraft.util.text.Style;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
@@ -77,15 +79,14 @@ public class SecretSignTileEntityRenderer extends TileEntityRenderer<SecretSignT
 
 			for(int line = 0; line < 4; ++line)
 			{
-				String text = te.getRenderText(line, textComponent -> {
-					List<ITextComponent> list = RenderComponentsUtil.splitText(textComponent, 90, font, false, true);
-
-					return list.isEmpty() ? "" : list.get(0).getFormattedText();
+				ITextProperties text = te.func_235677_a_(line, textComponent -> {
+					List<ITextProperties> list = font.func_238420_b_().func_238362_b_(textComponent, 90, Style.EMPTY);
+					return list.isEmpty() ? ITextProperties.field_240651_c_ : list.get(0);
 				});
 
 				if(text != null)
 				{
-					font.renderString(text, -font.getStringWidth(text) / 2, line * 10 - te.signText.length * 5, i1, false, stack.getLast().getMatrix(), buffer, false, 0, p_225616_5_);
+					font.func_238416_a_(text, -font.func_238414_a_(text) / 2, (float)(line * 10 - 20), i1, false, stack.getLast().getMatrix(), buffer, false, 0, p_225616_5_);
 				}
 			}
 		}

--- a/src/main/java/net/geforcemods/securitycraft/renderers/SecretSignTileEntityRenderer.java
+++ b/src/main/java/net/geforcemods/securitycraft/renderers/SecretSignTileEntityRenderer.java
@@ -86,7 +86,7 @@ public class SecretSignTileEntityRenderer extends TileEntityRenderer<SecretSignT
 
 				if(text != null)
 				{
-					font.func_238416_a_(text, -font.func_238414_a_(text) / 2, (float)(line * 10 - 20), i1, false, stack.getLast().getMatrix(), buffer, false, 0, p_225616_5_);
+					font.func_238416_a_(text, -font.func_238414_a_(text) / 2, line * 10 - 20, i1, false, stack.getLast().getMatrix(), buffer, false, 0, p_225616_5_);
 				}
 			}
 		}

--- a/src/main/java/net/geforcemods/securitycraft/screen/EditSecretSignScreen.java
+++ b/src/main/java/net/geforcemods/securitycraft/screen/EditSecretSignScreen.java
@@ -46,9 +46,7 @@ public class EditSecretSignScreen extends Screen
 	private int updateCounter;
 	private int editLine;
 	private TextInputUtil textInputUtil;
-	private final String[] signText = Util.make(new String[4], (i) -> {
-		Arrays.fill(i, "");
-	});
+	private final String[] signText = Util.make(new String[4], i -> Arrays.fill(i, ""));
 
 	public EditSecretSignScreen(SecretSignTileEntity te)
 	{
@@ -174,9 +172,9 @@ public class EditSecretSignScreen extends Screen
 
 			if(s != null)
 			{
-				if (this.font.getBidiFlag()) {
+				if (this.font.getBidiFlag())
 					s = this.font.bidiReorder(s);
-					
+
 				float f3 = -this.minecraft.fontRenderer.getStringWidth(s) / 2;
 
 				minecraft.fontRenderer.renderString(s, f3, k1 * 10 - signText.length * 5, textColor, false, positionMatrix, buffer, false, 0, 15728880);

--- a/src/main/java/net/geforcemods/securitycraft/screen/EditSecretSignScreen.java
+++ b/src/main/java/net/geforcemods/securitycraft/screen/EditSecretSignScreen.java
@@ -166,15 +166,6 @@ public class EditSecretSignScreen extends Screen
 		matrix.translate(0.0D, 0.33333334F, 0.046666667F);
 		matrix.scale(0.010416667F, -0.010416667F, 0.010416667F);
 
-		for(int j = 0; j < text.length; ++j)
-		{
-			text[j] = te.func_235677_a_(j, textComponent -> {
-				List<ITextProperties> list = RenderComponentsUtil.func_238505_a_(textComponent, 90, minecraft.fontRenderer);
-
-				return list.isEmpty() ? StringTextComponent.EMPTY : list.get(0);
-			}).getString();
-		}
-
 		positionMatrix = matrix.getLast().getMatrix();
 
 		for(int k1 = 0; k1 < text.length; ++k1)

--- a/src/main/java/net/geforcemods/securitycraft/screen/EditSecretSignScreen.java
+++ b/src/main/java/net/geforcemods/securitycraft/screen/EditSecretSignScreen.java
@@ -174,6 +174,9 @@ public class EditSecretSignScreen extends Screen
 
 			if(s != null)
 			{
+				if (this.font.getBidiFlag()) {
+					s = this.font.bidiReorder(s);
+					
 				float f3 = -this.minecraft.fontRenderer.getStringWidth(s) / 2;
 
 				minecraft.fontRenderer.renderString(s, f3, k1 * 10 - signText.length * 5, textColor, false, positionMatrix, buffer, false, 0, 15728880);

--- a/src/main/java/net/geforcemods/securitycraft/screen/EditSecretSignScreen.java
+++ b/src/main/java/net/geforcemods/securitycraft/screen/EditSecretSignScreen.java
@@ -129,7 +129,6 @@ public class EditSecretSignScreen extends Screen
 	@Override
 	public void render(MatrixStack matrix, int mouseX, int mouseY, float partialTicks)
 	{
-		MatrixStack stack = new MatrixStack();
 		BlockState state = this.te.getBlockState();
 		boolean isStanding = state.getBlock() instanceof StandingSignBlock;
 		boolean update = updateCounter / 6 % 2 == 0;
@@ -146,26 +145,26 @@ public class EditSecretSignScreen extends Screen
 		RenderHelper.setupGuiFlatDiffuseLighting();
 		renderBackground(matrix);
 		drawCenteredString(matrix, font, title, width / 2, 40, 16777215);
-		stack.push();
-		stack.translate(width / 2, 0.0D, 50.0D);
-		stack.scale(93.75F, -93.75F, 93.75F);
-		stack.translate(0.0D, -1.3125D, 0.0D);
+		matrix.push();
+		matrix.translate(width / 2, 0.0D, 50.0D);
+		matrix.scale(93.75F, -93.75F, 93.75F);
+		matrix.translate(0.0D, -1.3125D, 0.0D);
 
 		if(!isStanding)
-			stack.translate(0.0D, -0.3125D, 0.0D);
+			matrix.translate(0.0D, -0.3125D, 0.0D);
 
-		stack.push();
-		stack.scale(0.6666667F, -0.6666667F, -0.6666667F);
+		matrix.push();
+		matrix.scale(0.6666667F, -0.6666667F, -0.6666667F);
 		buffer = minecraft.getRenderTypeBuffers().getBufferSource();
 		builder = material.getBuffer(buffer, signModel::getRenderType);
-		signModel.signBoard.render(stack, builder, 15728880, OverlayTexture.NO_OVERLAY);
+		signModel.signBoard.render(matrix, builder, 15728880, OverlayTexture.NO_OVERLAY);
 
 		if(isStanding)
-			signModel.signStick.render(stack, builder, 15728880, OverlayTexture.NO_OVERLAY);
+			signModel.signStick.render(matrix, builder, 15728880, OverlayTexture.NO_OVERLAY);
 
-		stack.pop();
-		stack.translate(0.0D, 0.33333334F, 0.046666667F);
-		stack.scale(0.010416667F, -0.010416667F, 0.010416667F);
+		matrix.pop();
+		matrix.translate(0.0D, 0.33333334F, 0.046666667F);
+		matrix.scale(0.010416667F, -0.010416667F, 0.010416667F);
 
 		for(int j = 0; j < text.length; ++j)
 		{
@@ -176,7 +175,7 @@ public class EditSecretSignScreen extends Screen
 			}).getString();
 		}
 
-		positionMatrix = stack.getLast().getMatrix();
+		positionMatrix = matrix.getLast().getMatrix();
 
 		for(int k1 = 0; k1 < text.length; ++k1)
 		{
@@ -239,8 +238,8 @@ public class EditSecretSignScreen extends Screen
 			}
 		}
 
-		stack.pop();
+		matrix.pop();
 		RenderHelper.setupGui3DDiffuseLighting();
-		super.render(stack, mouseX, mouseY, partialTicks);
+		super.render(matrix, mouseX, mouseY, partialTicks);
 	}
 }

--- a/src/main/java/net/geforcemods/securitycraft/screen/EditSecretSignScreen.java
+++ b/src/main/java/net/geforcemods/securitycraft/screen/EditSecretSignScreen.java
@@ -62,10 +62,10 @@ public class EditSecretSignScreen extends Screen
 		minecraft.keyboardListener.enableRepeatEvents(true);
 		addButton(new Button(width / 2 - 100, height / 4 + 120, 200, 20, ClientUtils.localize("gui.done"), button -> close()));
 		te.setEditable(false);
-		textInputUtil = new TextInputUtil(() -> signText[editLine], (s) -> {
+		textInputUtil = new TextInputUtil(() -> signText[editLine], s -> {
 			signText[editLine] = s;
 			te.setText(editLine, new StringTextComponent(s));
-		}, TextInputUtil.func_238570_a_(minecraft), TextInputUtil.func_238582_c_(minecraft), (t) -> {
+		}, TextInputUtil.func_238570_a_(minecraft), TextInputUtil.func_238582_c_(minecraft), t -> {
 			return minecraft.fontRenderer.getStringWidth(t) <= 90;
 		});
 		System.out.println(editLine);

--- a/src/main/java/net/geforcemods/securitycraft/screen/EditSecretSignScreen.java
+++ b/src/main/java/net/geforcemods/securitycraft/screen/EditSecretSignScreen.java
@@ -65,10 +65,7 @@ public class EditSecretSignScreen extends Screen
 		textInputUtil = new TextInputUtil(() -> signText[editLine], s -> {
 			signText[editLine] = s;
 			te.setText(editLine, new StringTextComponent(s));
-		}, TextInputUtil.func_238570_a_(minecraft), TextInputUtil.func_238582_c_(minecraft), t -> {
-			return minecraft.fontRenderer.getStringWidth(t) <= 90;
-		});
-		System.out.println(editLine);
+		}, TextInputUtil.func_238570_a_(minecraft), TextInputUtil.func_238582_c_(minecraft), t -> minecraft.fontRenderer.getStringWidth(t) <= 90);
 	}
 
 	@Override
@@ -141,7 +138,6 @@ public class EditSecretSignScreen extends Screen
 		String[] text = new String[4];
 		int k = textInputUtil.func_216896_c();
 		int l = textInputUtil.func_216898_d();
-		int i1 = minecraft.fontRenderer.getBidiFlag() ? -1 : 1;
 		int j1 = editLine * 10 - signText.length * 5;
 		IRenderTypeBuffer.Impl buffer;
 		IVertexBuilder builder;
@@ -195,7 +191,7 @@ public class EditSecretSignScreen extends Screen
 				if(k1 == this.editLine && k >= 0 && update)
 				{
 					int l1 = minecraft.fontRenderer.getStringWidth(s.substring(0, Math.max(Math.min(k, s.length()), 0)));
-					int i2 = (l1 - minecraft.fontRenderer.getStringWidth(s) / 2) * i1;
+					int i2 = l1 - minecraft.fontRenderer.getStringWidth(s) / 2;
 
 					if(k >= s.length())
 						minecraft.fontRenderer.renderString("_", i2, j1, textColor, false, positionMatrix, buffer, false, 0, 15728880);
@@ -212,7 +208,7 @@ public class EditSecretSignScreen extends Screen
 			if(s1 != null && k3 == editLine && k >= 0)
 			{
 				int l3 = minecraft.fontRenderer.getStringWidth(s1.substring(0, Math.max(Math.min(k, s1.length()), 0)));
-				int i4 = (l3 - minecraft.fontRenderer.getStringWidth(s1) / 2) * i1;
+				int i4 = l3 - minecraft.fontRenderer.getStringWidth(s1) / 2;
 
 				if(update && k < s1.length())
 					fill(matrix, i4, j1 - 1, i4 + 1, j1 + 9, -16777216 | textColor);
@@ -221,8 +217,8 @@ public class EditSecretSignScreen extends Screen
 				{
 					int j4 = Math.min(k, l);
 					int j2 = Math.max(k, l);
-					int k2 = (this.minecraft.fontRenderer.getStringWidth(s1.substring(0, j4)) - this.minecraft.fontRenderer.getStringWidth(s1) / 2) * i1;
-					int l2 = (this.minecraft.fontRenderer.getStringWidth(s1.substring(0, j2)) - this.minecraft.fontRenderer.getStringWidth(s1) / 2) * i1;
+					int k2 = this.minecraft.fontRenderer.getStringWidth(s1.substring(0, j4)) - this.minecraft.fontRenderer.getStringWidth(s1) / 2;
+					int l2 = this.minecraft.fontRenderer.getStringWidth(s1.substring(0, j2)) - this.minecraft.fontRenderer.getStringWidth(s1) / 2;
 					int i3 = Math.min(k2, l2);
 					int j3 = Math.max(k2, l2);
 					BufferBuilder buf = Tessellator.getInstance().getBuffer();


### PR DESCRIPTION
In this PR I ported the SecretSign to 1.16. There were some changes because the fields in the SignTileEntity are private in this version, but nothing too major was changed to make the sign work again.