### PR TITLE
Fixed reinforced double stone slab not being tinted

### DIFF
--- a/src/main/resources/assets/securitycraft/blockstates/reinforced_normal_stone_slab.json
+++ b/src/main/resources/assets/securitycraft/blockstates/reinforced_normal_stone_slab.json
@@ -2,6 +2,6 @@
     "variants": {
         "type=top": { "model": "securitycraft:block/reinforced_top_slab_normal_stone" },
         "type=bottom": { "model": "securitycraft:block/reinforced_half_slab_normal_stone" },
-        "type=double": { "model": "block/stone" }
+        "type=double": { "model": "securitycraft:block/reinforced_stone" }
     }
 }


### PR DESCRIPTION
A small, but still a pretty annoying bug that I fixed by tweaking one line. (not like you could've also done this :P)
Also my first, not porting related PR in the 1.16.x branch pog