### PR TITLE
Fixed valid inventory scanner field not being replaced when destroyed

### DIFF
--- a/Changelog v1.8.x.md
+++ b/Changelog v1.8.x.md
@@ -9,6 +9,7 @@
 - New: Block/item tags: securitycraft:reinforced/crimson_stems, securitycraft:reinforced/nylium, securitycraft:reinforced/pressure_plates, securitycraft:reinforced/warped_stems (Thanks Redstone_Dubstep!)
 - New: Support for the following block/item tags: minecraft:infiniburn_overworld, minecraft:mushroom_grow_block, minecraft:nylium, minecraft:pressure_plates, minecraft:soul_fire_base_blocks, minecraft:soul_speed_blocks, minecraft:strider_warm_blocks, minecraft:wither_summon_base_blocks, minecraft:piglin_loved (Thanks Redstone_Dubstep!)
 - Change: Sounds of reinforced blocks to match sounds of their vanilla equivalent (Thanks Redstone_Dubstep!)
+- Change: Inventory Scanner Fields now cannot be destroyed when between two Inventory Scanners (Thanks Redstone_Dubstep!) 
 - Fix: WAILA exploit
 - Fix: Double Stone Slab has no tint (Thanks Redstone_Dubstep!)
 - Fix: Incorrect item group name

--- a/src/main/java/net/geforcemods/securitycraft/blocks/InventoryScannerBlock.java
+++ b/src/main/java/net/geforcemods/securitycraft/blocks/InventoryScannerBlock.java
@@ -69,17 +69,14 @@ public class InventoryScannerBlock extends DisguisableBlock {
 		if(world.isRemote)
 			return;
 
-		checkAndPlaceAppropriately(world, pos, entity);
+		checkAndPlaceAppropriately(world, pos);
 	}
 
-	private void checkAndPlaceAppropriately(World world, BlockPos pos, LivingEntity entity)
+	private void checkAndPlaceAppropriately(World world, BlockPos pos)
 	{
-		if(!(entity instanceof PlayerEntity))
-			return;
-
 		InventoryScannerTileEntity connectedScanner = getConnectedInventoryScanner(world, pos);
 
-		if(connectedScanner == null || !connectedScanner.getOwner().isOwner((PlayerEntity)entity))
+		if(connectedScanner == null || !connectedScanner.getOwner().equals(((InventoryScannerTileEntity)world.getTileEntity(pos)).getOwner()))
 			return;
 
 		Direction facing = world.getBlockState(pos).get(FACING);
@@ -175,6 +172,11 @@ public class InventoryScannerBlock extends DisguisableBlock {
 		}
 
 		return null;
+	}
+
+	@Override
+	public void onNeighborChange(BlockState state, IWorldReader world, BlockPos pos, BlockPos neighbor) {
+		checkAndPlaceAppropriately((World)world, pos);
 	}
 
 	/**

--- a/src/main/java/net/geforcemods/securitycraft/blocks/InventoryScannerFieldBlock.java
+++ b/src/main/java/net/geforcemods/securitycraft/blocks/InventoryScannerFieldBlock.java
@@ -237,10 +237,18 @@ public class InventoryScannerFieldBlock extends OwnableBlock implements IInterse
 	{
 		if(!world.isRemote())
 		{
-			checkAndDestroyFields(world, pos, (p, i) -> p.west(i));
-			checkAndDestroyFields(world, pos, (p, i) -> p.east(i));
-			checkAndDestroyFields(world, pos, (p, i) -> p.north(i));
-			checkAndDestroyFields(world, pos, (p, i) -> p.south(i));
+			Direction facing = state.get(FACING);
+
+			if (facing == Direction.EAST || facing == Direction.WEST)
+			{
+				checkAndDestroyFields(world, pos, (p, i) -> p.west(i));
+				checkAndDestroyFields(world, pos, (p, i) -> p.east(i));
+			}
+			else if (facing == Direction.NORTH || facing == Direction.SOUTH)
+			{
+				checkAndDestroyFields(world, pos, (p, i) -> p.north(i));
+				checkAndDestroyFields(world, pos, (p, i) -> p.south(i));
+			}
 		}
 	}
 
@@ -254,7 +262,7 @@ public class InventoryScannerFieldBlock extends OwnableBlock implements IInterse
 			{
 				for(int j = 1; j < i; j++)
 				{
-					world.destroyBlock(modifiedPos, false);
+					world.destroyBlock(posModifier.apply(pos, j), false);
 				}
 
 				break;


### PR DESCRIPTION
In this PR I've added a method to the InventoryScannerBlock that makes it replace a valid inventory scanner field when it gets destroyed, just like it happens with lasers. I had to remove a check if the placer of the scanner is a player, please let me know if that check was of importance.