### PR TITLE
Fixed the "Confirm" button of the Key Changer screen not disabling again

### DIFF
--- a/src/main/java/net/geforcemods/securitycraft/screen/KeyChangerScreen.java
+++ b/src/main/java/net/geforcemods/securitycraft/screen/KeyChangerScreen.java
@@ -111,6 +111,7 @@ public class KeyChangerScreen extends ContainerScreen<GenericTEContainer> {
 			{
 				Minecraft.getInstance().player.playSound(ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("random.click")), 0.15F, 1.0F);
 				focusedTextField.setText(Utils.removeLastChar(focusedTextField.getText()));
+				checkToEnableSaveButton();
 				return true;
 			}
 		}
@@ -148,10 +149,7 @@ public class KeyChangerScreen extends ContainerScreen<GenericTEContainer> {
 		String newPasscode = !textboxNewPasscode.getText().isEmpty() ? textboxNewPasscode.getText() : null;
 		String confirmedPasscode = !textboxConfirmPasscode.getText().isEmpty() ? textboxConfirmPasscode.getText() : null;
 
-		if(newPasscode == null || confirmedPasscode == null) return;
-		if(!newPasscode.equals(confirmedPasscode)) return;
-
-		confirmButton.active = true;
+		confirmButton.active = !(newPasscode == null || confirmedPasscode == null) && newPasscode.equals(confirmedPasscode);
 	}
 
 	@Override


### PR DESCRIPTION
In this PR I've fixed the "Confirm" button of the Universal Key Changer not disabling again after it has been enabled once. The method handling the activation of the button now also handles the deactivation of it (and looks a bit cleaner now), and there is now a check in `KeyChangerScreen.keyPressed()` that updates the button if you press backspace.