### PR TITLE
Improved the Keycard Reader a bit

### DIFF
--- a/Changelog v1.8.x.md
+++ b/Changelog v1.8.x.md
@@ -13,6 +13,7 @@
 - New: Inventory Scanner modifying option to have inventory scanner fields be horizontal
 - New: A briefcase's owner can now be changed if its owner rightclicks while holding the briefcase in their off hand and a named Universal Owner Changer in their main hand (Thanks Redstone_Dubstep!)
 - New: The codebreaker can now be used on a briefcase by holding the briefcase in the off hand and the codebreaker in the main hand and rightclicking (Thanks Redstone_Dubstep!)
+- New: Customization option to change how long the Keycard Reader emits a redstone signal when it has been activated (Thanks Redstone_Dubstep!)
 - Change: Sounds of reinforced blocks now match the sounds of their vanilla equivalent (Thanks Redstone_Dubstep!)
 - Change: Inventory Scanner Fields now cannot be destroyed when between two Inventory Scanners (Thanks Redstone_Dubstep!)
 - Change: Laser and Taser damage no longer bypasses armor
@@ -25,6 +26,7 @@
 - Fix: Anyone can reset a briefcase's passcode (Thanks Redstone_Dubstep!)
 - Fix: Confirm button in the Universal Key Changer's GUI doesn't properly react to changes in the textboxes (Thanks Redstone_Dubstep!)
 - Fix: Defused Claymore model is incorrect (Thanks Redstone_Dubstep!)
+- Fix: Keycard Reader sometimes sends incorrect messages (Thanks Redstone_Dubstep!)
 - Removed: Taser Bullet entity
 - Misc.: Various French language fixes (Thanks supercat95!)
 

--- a/src/main/java/net/geforcemods/securitycraft/blocks/KeycardReaderBlock.java
+++ b/src/main/java/net/geforcemods/securitycraft/blocks/KeycardReaderBlock.java
@@ -51,10 +51,11 @@ public class KeycardReaderBlock extends DisguisableBlock  {
 		boolean whitelisted = ModuleUtils.checkForModule(world, pos, player, ModuleType.WHITELIST);
 		int requiredLevel = -1;
 		int cardLvl = ((BaseKeycardItem) stack.getItem()).getKeycardLvl();
-		boolean exact = ((KeycardReaderTileEntity)world.getTileEntity(pos)).doesRequireExactKeycard();
+		KeycardReaderTileEntity te = ((KeycardReaderTileEntity)world.getTileEntity(pos));
+		boolean exact = te.doesRequireExactKeycard();
 
-		if(((KeycardReaderTileEntity)world.getTileEntity(pos)).getPassword() != null)
-			requiredLevel = Integer.parseInt(((KeycardReaderTileEntity)world.getTileEntity(pos)).getPassword());
+		if(te.getPassword() != null)
+			requiredLevel = Integer.parseInt(te.getPassword());
 
 		if(whitelisted || (!exact && requiredLevel <= cardLvl || exact && requiredLevel == cardLvl)){
 			if(cardLvl == 6 && stack.getTag() != null && !player.isCreative()){
@@ -64,14 +65,12 @@ public class KeycardReaderBlock extends DisguisableBlock  {
 					stack.shrink(1);
 			}
 
-			KeycardReaderBlock.activate(world, pos, ((KeycardReaderTileEntity)world.getTileEntity(pos)).getSignalLength());
+			KeycardReaderBlock.activate(world, pos, te.getSignalLength());
 		}
-		else if (requiredLevel == -1) {
-			if(world.isRemote)
+		else if (world.isRemote) {
+			if(requiredLevel == -1)
 				PlayerUtils.sendMessageToPlayer(player, ClientUtils.localize(SCContent.KEYCARD_READER.get().getTranslationKey()), ClientUtils.localize("messages.securitycraft:keycardReader.notSet"), TextFormatting.RED);
-		}
-		else {
-			if (world.isRemote)
+			else
 				PlayerUtils.sendMessageToPlayer(player, ClientUtils.localize(SCContent.KEYCARD_READER.get().getTranslationKey()), ClientUtils.localize("messages.securitycraft:keycardReader.required", ((IPasswordProtected) world.getTileEntity(pos)).getPassword(), ((BaseKeycardItem) stack.getItem()).getKeycardLvl()), TextFormatting.RED);
 		}
 	}

--- a/src/main/java/net/geforcemods/securitycraft/blocks/KeycardReaderBlock.java
+++ b/src/main/java/net/geforcemods/securitycraft/blocks/KeycardReaderBlock.java
@@ -63,7 +63,7 @@ public class KeycardReaderBlock extends DisguisableBlock  {
 					stack.shrink(1);
 			}
 
-			KeycardReaderBlock.activate(world, pos);
+			KeycardReaderBlock.activate(world, pos, ((KeycardReaderTileEntity)world.getTileEntity(pos)).getSignalLength());
 		}
 
 		if(world.isRemote)

--- a/src/main/java/net/geforcemods/securitycraft/blocks/KeycardReaderBlock.java
+++ b/src/main/java/net/geforcemods/securitycraft/blocks/KeycardReaderBlock.java
@@ -3,7 +3,6 @@ package net.geforcemods.securitycraft.blocks;
 import java.util.Random;
 
 import net.geforcemods.securitycraft.SCContent;
-import net.geforcemods.securitycraft.api.IPasswordProtected;
 import net.geforcemods.securitycraft.items.BaseKeycardItem;
 import net.geforcemods.securitycraft.misc.ModuleType;
 import net.geforcemods.securitycraft.tileentity.KeycardReaderTileEntity;
@@ -71,7 +70,7 @@ public class KeycardReaderBlock extends DisguisableBlock  {
 			if(requiredLevel == -1)
 				PlayerUtils.sendMessageToPlayer(player, ClientUtils.localize(SCContent.KEYCARD_READER.get().getTranslationKey()), ClientUtils.localize("messages.securitycraft:keycardReader.notSet"), TextFormatting.RED);
 			else
-				PlayerUtils.sendMessageToPlayer(player, ClientUtils.localize(SCContent.KEYCARD_READER.get().getTranslationKey()), ClientUtils.localize("messages.securitycraft:keycardReader.required", ((IPasswordProtected) world.getTileEntity(pos)).getPassword(), ((BaseKeycardItem) stack.getItem()).getKeycardLvl()), TextFormatting.RED);
+				PlayerUtils.sendMessageToPlayer(player, ClientUtils.localize(SCContent.KEYCARD_READER.get().getTranslationKey()), ClientUtils.localize("messages.securitycraft:keycardReader.required", te.getPassword(), ((BaseKeycardItem) stack.getItem()).getKeycardLvl()), TextFormatting.RED);
 		}
 	}
 

--- a/src/main/java/net/geforcemods/securitycraft/tileentity/KeycardReaderTileEntity.java
+++ b/src/main/java/net/geforcemods/securitycraft/tileentity/KeycardReaderTileEntity.java
@@ -28,6 +28,7 @@ public class KeycardReaderTileEntity extends DisguisableTileEntity implements IP
 	private int passLV = 0;
 	private boolean requiresExactKeycard = false;
 	private BooleanOption sendMessage = new BooleanOption("sendMessage", true);
+	private Option.IntOption signalLength = new Option.IntOption(this, "signalLength", 60, 5, 400, 5, true); //20 seconds max
 
 	public KeycardReaderTileEntity()
 	{
@@ -72,7 +73,7 @@ public class KeycardReaderTileEntity extends DisguisableTileEntity implements IP
 	@Override
 	public void activate(PlayerEntity player) {
 		if(!world.isRemote && BlockUtils.getBlock(getWorld(), getPos()) instanceof KeycardReaderBlock)
-			KeycardReaderBlock.activate(world, getPos());
+			KeycardReaderBlock.activate(world, getPos(), signalLength.get());
 	}
 
 	@Override
@@ -108,12 +109,17 @@ public class KeycardReaderTileEntity extends DisguisableTileEntity implements IP
 
 	@Override
 	public Option<?>[] customOptions() {
-		return new Option[]{ sendMessage };
+		return new Option[]{ sendMessage, signalLength };
 	}
 
 	public boolean sendsMessages()
 	{
 		return sendMessage.get();
+	}
+
+	public int getSignalLength()
+	{
+		return signalLength.get();
 	}
 
 	@Override

--- a/src/main/resources/assets/securitycraft/lang/de_de.json
+++ b/src/main/resources/assets/securitycraft/lang/de_de.json
@@ -935,6 +935,8 @@
 	"option.securitycraft.motion_activated_light.searchRadius.description": "Wie weit entfernt erkennt das Licht einen Mob/Spieler?",
 	"option.securitycraft.keycard_reader.sendMessage": "Nachricht: %s",
 	"option.securitycraft.keycard_reader.sendMessage.description": "Sendet dieser Schlüsselkartenleser eine Nachricht, wenn er aktiviert wird (bei Nutzung von Whitelist/Blacklist Modulen)?",
+	"option.securitycraft.keycard_reader.signalLength": "Signallänge: %s",
+	"option.securitycraft.keycard_reader.signalLength.description": "Wie lange soll das Redstonesignal bei erfolgreicher Aktivierung sein? (In Ticks, 20 Ticks = 1 Sekunde)",
 	"option.securitycraft.keypad_chest.sendMessage": "Nachricht: %s",
 	"option.securitycraft.keypad_chest.sendMessage.description": "Sendet diese Truhe eine Nachricht, wenn sie aktiviert wird (bei Nutzung von Whitelist/Blacklist Modulen)?",
 	"option.securitycraft.keypad_furnace.sendMessage": "Nachricht: %s",

--- a/src/main/resources/assets/securitycraft/lang/en_us.json
+++ b/src/main/resources/assets/securitycraft/lang/en_us.json
@@ -938,6 +938,8 @@
 	"option.securitycraft.motion_activated_light.searchRadius.description": "How far will the light detect an entity?",
 	"option.securitycraft.keycard_reader.sendMessage": "Message: %s",
 	"option.securitycraft.keycard_reader.sendMessage.description": "Does this keycard reader send a message upon activation (when using whitelist/blacklist modules)?",
+	"option.securitycraft.keycard_reader.signalLength": "Signal length: %s",
+	"option.securitycraft.keycard_reader.signalLength.description": "How long should the redstone signal upon successful activation be? (In ticks, 20 ticks = 1 second)",
 	"option.securitycraft.keypad_chest.sendMessage": "Message: %s",
 	"option.securitycraft.keypad_chest.sendMessage.description": "Does this chest send a message upon activation (when using whitelist/blacklist modules)?",
 	"option.securitycraft.keypad_furnace.sendMessage": "Message: %s",

--- a/src/main/resources/assets/securitycraft/lang/es_es.json
+++ b/src/main/resources/assets/securitycraft/lang/es_es.json
@@ -873,6 +873,8 @@
 	"option.securitycraft.motion_activated_light.searchRadius.description": "¿A cuánta distancia detecta la luz a una entidad?",
 	"option.securitycraft.keycard_reader.sendMessage": "Mensaje: %s",
 	"option.securitycraft.keycard_reader.sendMessage.description": "¿Este lector de tarjetas envía un mensaje al activarse (cuando se usan módulos de lista blanca/negra)?",
+	"option.securitycraft.keycard_reader.signalLength": "Longitud de la señal: %s",
+	"option.securitycraft.keycard_reader.signalLength.description": "¿Cómo de larga debería ser la señal de redstone que se emite tras activarse? (En ticks, 20 ticks = 1 segundo)",
 	"option.securitycraft.keypad_chest.sendMessage": "Mensaje: %s",
 	"option.securitycraft.keypad_chest.sendMessage.description": "¿Este cofre envía un mensaje al ser activado (cuando se usa un módulo de lista blanca/negra)?",
 	"option.securitycraft.keypad_furnace.sendMessage": "Mensaje: %s",

--- a/src/main/resources/assets/securitycraft/lang/fr_fr.json
+++ b/src/main/resources/assets/securitycraft/lang/fr_fr.json
@@ -869,6 +869,8 @@
 	"option.securitycraft.motion_activated_light.searchRadius.description": "À quelle distance la lumière pourra détecter une entité ?",
 	"option.securitycraft.keycard_reader.sendMessage": "Message : %s",
 	"option.securitycraft.keycard_reader.sendMessage.description": "Cette carte d'accès envoie-t-elle un message lors de l'activation (quand utilisant des modules de liste blanche/noire) ?",
+	"option.securitycraft.keycard_reader.signalLength": "Largeur du signal : %s",
+	"option.securitycraft.keycard_reader.signalLength.description": "Pour combien de temps resterait le signal de redstone en cas de succès ? (En ticks, 20 ticks = 1 seconde)",
 	"option.securitycraft.keypad_chest.sendMessage": "Message : %s",
 	"option.securitycraft.keypad_chest.sendMessage.description": "Ce coffre protégé par un clavier à code envoie-t-il un message lors de l'activation (quand utilisant des modules de liste blanche/noire) ?",
 	"option.securitycraft.keypad_furnace.sendMessage": "Message : %s",

--- a/src/main/resources/assets/securitycraft/lang/it_it.json
+++ b/src/main/resources/assets/securitycraft/lang/it_it.json
@@ -869,6 +869,8 @@
 	"option.securitycraft.alarm.range.description": "Da quanti blocchi di distanza si può udire il suono dell'allarme?",
 	"option.securitycraft.keycard_reader.sendMessage": "Messaggio: %s",
 	"option.securitycraft.keycard_reader.sendMessage.description": "Questo lettore di tessere magnetiche manda un messaggio all'attivazione (usando moduli lista bianca/nera)?",
+	"option.securitycraft.keycard_reader.signalLength": "Lunghezza segnale: %s",
+	"option.securitycraft.keycard_reader.signalLength.description": "Quanto dovrebbe durare un segnale di redstone dall'attivazione? (In tick, 20 tick = 1 secondo)",
 	"option.securitycraft.keypad_chest.sendMessage": "Messaggio: %s",
 	"option.securitycraft.keypad_chest.sendMessage.description": "Questo baule manda un messaggio all'attivazione (usando moduli lista bianca/nera)?",
 	"option.securitycraft.keypad_furnace.sendMessage": "Messaggio: %s",


### PR DESCRIPTION
In this PR I looked at the Keycard Reader and was able to add/fix two things:
1. The Keycard Reader now has a signal length customization option that works the same as the one in the keypad
2. The `KeycardReaderBlock.insertCard` method has been cleaned up for better readability, this also fixed a bug where a whitelisted player with a wrong keycard would get whitelisted, but would still get the message that their keycard level is wrong