### PR TITLE
Fix instances of forge:dyes/gray in light gray recipes.

### DIFF
--- a/src/generated/resources/data/securitycraft/recipes/reinforced_light_gray_stained_glass.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_light_gray_stained_glass.json
@@ -11,7 +11,7 @@
       "item": "securitycraft:reinforced_glass"
     },
     "D": {
-      "tag": "forge:dyes/gray"
+      "tag": "forge:dyes/light_gray"
     }
   },
   "result": {

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_light_gray_stained_glass_pane_from_dye.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_light_gray_stained_glass_pane_from_dye.json
@@ -11,7 +11,7 @@
       "item": "securitycraft:reinforced_glass_pane"
     },
     "D": {
-      "tag": "forge:dyes/gray"
+      "tag": "forge:dyes/light_gray"
     }
   },
   "result": {

--- a/src/generated/resources/data/securitycraft/recipes/reinforced_light_gray_terracotta.json
+++ b/src/generated/resources/data/securitycraft/recipes/reinforced_light_gray_terracotta.json
@@ -11,7 +11,7 @@
       "item": "securitycraft:reinforced_hardened_clay"
     },
     "D": {
-      "tag": "forge:dyes/gray"
+      "tag": "forge:dyes/light_gray"
     }
   },
   "result": {


### PR DESCRIPTION
This pull request simply fixes instances where `forge:dyes/gray` incorrectly appears in recipes named after light_gray. Right now, the recipe is the same for both light_gray class, and gray glass.

https://i.imgur.com/wDQWoNV.png
https://i.imgur.com/5aTgUi1.png


Occurs in
* recipes/reinforced_light_gray_stained_glass.json
* recipes/reinforced_light_gray_stained_glass_pane_from_dye.json
* recipes/reinforced_light_gray_terracotta.json