### PR TITLE
Fix minor issue with manual

### DIFF
--- a/src/main/java/net/geforcemods/securitycraft/misc/PageGroup.java
+++ b/src/main/java/net/geforcemods/securitycraft/misc/PageGroup.java
@@ -9,7 +9,7 @@ public enum PageGroup {
 	BUTTONS(true, "gui.securitycraft:scManual.reinforced_buttons", "securitycraft.reinforced_buttons.info"),
 	PRESSURE_PLATES(true, "gui.securitycraft:scManual.reinforced_pressure_plates", "securitycraft.reinforced_pressure_plates.info"),
 	FURNACE_MINES(true, "block.securitycraft.furnace_mine", "securitycraft.furnace_mines.info"),
-	KEYCARDS(true, "gui.securitycraft:scManual.keycards", "securitycraft.secret_signs.info"),
+	KEYCARDS(true, "gui.securitycraft:scManual.keycards", "securitycraft.keycards.info"),
 	SECRET_SIGNS(true, "gui.securitycraft:scManual.secret_signs", "securitycraft.secret_signs.info"),
 	BLOCK_REINFORCERS(true, "gui.securitycraft:scManual.block_reinforcers", "securitycraft.block_reinforcers.info");
 


### PR DESCRIPTION
Updated so keycards contain the info for keycards instead of secret_signs

Original issue:
<img width="510" alt="image" src="https://user-images.githubusercontent.com/9203761/180078605-4f5696f0-e5b4-414c-8cf6-76fe035c4a32.png">
<img width="362" alt="image" src="https://user-images.githubusercontent.com/9203761/180078710-dbc451ec-ef02-49bc-b091-a955c2254121.png">
