### PR TITLE
[1.21.11] fix singleplayer recipe loading crash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ sourceSets.main.resources {
 }
 
 neoForge {
-	version = "21.11.12-beta"
+	version = "21.11.13-beta"
 	validateAccessTransformers = true
 
 	runs {

--- a/src/main/java/net/geforcemods/securitycraft/items/SCManualItem.java
+++ b/src/main/java/net/geforcemods/securitycraft/items/SCManualItem.java
@@ -104,7 +104,10 @@ public class SCManualItem extends Item {
 
 	private static ItemStack safeAssemble(CraftingRecipe recipe, CraftingInput dummyInput, HolderLookup.Provider registryAccess) {
 		try {
-			return recipe.assemble(dummyInput, registryAccess);
+			var res = recipe.assemble(dummyInput, registryAccess);
+			if (res == null) {
+				return ItemStack.EMPTY;
+			}
 		}
 		catch (Exception e) {
 			//If an exception is thrown, it's safe to assume that recipe assembling failed for some reason that means the recipe is not relevant for one of SC's items


### PR DESCRIPTION
fixes crash when loading single player worlds. seems the assemble method can return null to indicate an error too. I tested it and this fixes it for me.

also, the JEI version you added requires neoforge 13-beta so I bumped that too