### PR TITLE
Fix GUIs closing immediatelly after opening them on a multiplayer server

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+--------------------------Changelog for the next version of SecurityCraft--------------------------
+
+- Fix: Some UIs stay open, even though the player is no longer near the block or holding the item
+
 --------------------------Changelog for v1.10.2.1-beta1 of SecurityCraft--------------------------
 
 - Fix: Some of SecurityCraft's UIs immediately close and/or cause other players to get kicked

--- a/src/main/java/net/geforcemods/securitycraft/SCClientEventHandler.java
+++ b/src/main/java/net/geforcemods/securitycraft/SCClientEventHandler.java
@@ -198,7 +198,7 @@ public class SCClientEventHandler {
 	public static void onPlayerTickPre(PlayerTickEvent.Pre event) {
 		Minecraft mc = Minecraft.getInstance();
 
-		if (mc.gui.screen() instanceof StillValid screen && !screen.stillValid(event.getEntity()))
+		if (event.getEntity() == mc.player && mc.gui.screen() instanceof StillValid screen && !screen.stillValid(event.getEntity()))
 			mc.gui.setScreen(null);
 	}
 

--- a/src/main/java/net/geforcemods/securitycraft/SCClientEventHandler.java
+++ b/src/main/java/net/geforcemods/securitycraft/SCClientEventHandler.java
@@ -103,11 +103,12 @@ public class SCClientEventHandler {
 	@SubscribeEvent
 	public static void onClientTickPost(ClientTickEvent.Post event) {
 		Minecraft mc = Minecraft.getInstance();
+
 		if (cameraInfoMessageTime >= 0)
 			cameraInfoMessageTime--;
 
 		//move the GUI closing mechanism to onClientTickPost
-		if (mc.player != null && mc.gui.screen() instanceof StillValid screen && !screen.stillValid(mc.player))
+		if (mc != null && mc.gui.screen() instanceof StillValid screen && !screen.stillValid(mc.player))
 			mc.gui.setScreen(null);
 	}
 

--- a/src/main/java/net/geforcemods/securitycraft/SCClientEventHandler.java
+++ b/src/main/java/net/geforcemods/securitycraft/SCClientEventHandler.java
@@ -62,7 +62,6 @@ import net.neoforged.neoforge.client.resources.VanillaClientListeners;
 import net.neoforged.neoforge.event.entity.player.ItemTooltipEvent;
 import net.neoforged.neoforge.event.level.ChunkEvent;
 import net.neoforged.neoforge.event.level.LevelEvent;
-import net.neoforged.neoforge.event.tick.PlayerTickEvent;
 import net.neoforged.neoforge.registries.DeferredHolder;
 
 @EventBusSubscriber(modid = SecurityCraft.MODID, value = Dist.CLIENT)
@@ -103,8 +102,13 @@ public class SCClientEventHandler {
 
 	@SubscribeEvent
 	public static void onClientTickPost(ClientTickEvent.Post event) {
+		Minecraft mc = Minecraft.getInstance();
 		if (cameraInfoMessageTime >= 0)
 			cameraInfoMessageTime--;
+
+		//move the GUI closing mechanism to onClientTickPost
+		if (mc.player != null && mc.gui.screen() instanceof StillValid screen && !screen.stillValid(mc.player))
+			mc.gui.setScreen(null);
 	}
 
 	@SubscribeEvent
@@ -192,14 +196,6 @@ public class SCClientEventHandler {
 				}, flag, stack.getComponents());
 			}
 		}
-	}
-
-	@SubscribeEvent
-	public static void onPlayerTickPre(PlayerTickEvent.Pre event) {
-		Minecraft mc = Minecraft.getInstance();
-
-		if (event.getEntity() == mc.player && mc.gui.screen() instanceof StillValid screen && !screen.stillValid(event.getEntity()))
-			mc.gui.setScreen(null);
 	}
 
 	public static void cameraOverlay(GuiGraphicsExtractor guiGraphics, DeltaTracker deltaTracker) {

--- a/src/main/java/net/geforcemods/securitycraft/SCClientEventHandler.java
+++ b/src/main/java/net/geforcemods/securitycraft/SCClientEventHandler.java
@@ -107,7 +107,6 @@ public class SCClientEventHandler {
 		if (cameraInfoMessageTime >= 0)
 			cameraInfoMessageTime--;
 
-		//move the GUI closing mechanism to onClientTickPost
 		if (mc != null && mc.gui.screen() instanceof StillValid screen && !screen.stillValid(mc.player))
 			mc.gui.setScreen(null);
 	}


### PR DESCRIPTION
Fix an issue where GUIs close immidiatelly after opened when the person who placed the door is not near.

The problem was that the tick handler calling stillValid didn't filter which player it checked. With this addition, stillValid is only checked against the player who has the GUI open.