### PR TITLE
Fix trapdoors facing the wrong direction visually when placed facing west or east

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 --------------------------Changelog for the next version of SecurityCraft--------------------------
 
 - Fix: Some UIs stay open, even though the player is no longer near the block or holding the item
+- Fix: Reinforced, Keypad, and Scanner Trapdoors show up incorrectly when open and facing east or west (Thanks CYB3RCA4T!)
 
 --------------------------Changelog for v1.10.2.1-beta1 of SecurityCraft--------------------------
 

--- a/src/main/resources/assets/securitycraft/blockstates/keypad_trapdoor.json
+++ b/src/main/resources/assets/securitycraft/blockstates/keypad_trapdoor.json
@@ -1,20 +1,20 @@
 {
-	"variants": {
-		"facing=north,half=bottom,open=false": { "model": "securitycraft:block/keypad_trapdoor_bottom", "y": 180 },
-		"facing=south,half=bottom,open=false": { "model": "securitycraft:block/keypad_trapdoor_bottom" },
-		"facing=east,half=bottom,open=false": { "model": "securitycraft:block/keypad_trapdoor_bottom", "y": 270 },
-		"facing=west,half=bottom,open=false": { "model": "securitycraft:block/keypad_trapdoor_bottom", "y": 90 },
-		"facing=north,half=top,open=false": { "model": "securitycraft:block/keypad_trapdoor_top", "y": 180 },
-		"facing=south,half=top,open=false": { "model": "securitycraft:block/keypad_trapdoor_top" },
-		"facing=east,half=top,open=false": { "model": "securitycraft:block/keypad_trapdoor_top", "y": 270 },
-		"facing=west,half=top,open=false": { "model": "securitycraft:block/keypad_trapdoor_top", "y": 90 },
-		"facing=north,half=bottom,open=true": { "model": "securitycraft:block/keypad_trapdoor_open", "z": 180 },
-		"facing=south,half=bottom,open=true": { "model": "securitycraft:block/keypad_trapdoor_open", "y": 180, "z": 180 },
-		"facing=east,half=bottom,open=true": { "model": "securitycraft:block/keypad_trapdoor_open", "y": 270, "z": 180 },
-		"facing=west,half=bottom,open=true": { "model": "securitycraft:block/keypad_trapdoor_open", "y": 90, "z": 180 },
-		"facing=north,half=top,open=true": { "model": "securitycraft:block/keypad_trapdoor_open" },
-		"facing=south,half=top,open=true": { "model": "securitycraft:block/keypad_trapdoor_open", "y": 180 },
-		"facing=east,half=top,open=true": { "model": "securitycraft:block/keypad_trapdoor_open", "y": 90 },
-		"facing=west,half=top,open=true": { "model": "securitycraft:block/keypad_trapdoor_open", "y": 270 }
-	}
+    "variants": {
+        "facing=north,half=bottom,open=false": { "model": "securitycraft:block/keypad_trapdoor_bottom", "y": 180 },
+        "facing=south,half=bottom,open=false": { "model": "securitycraft:block/keypad_trapdoor_bottom" },
+        "facing=east,half=bottom,open=false": { "model": "securitycraft:block/keypad_trapdoor_bottom", "y": 270 },
+        "facing=west,half=bottom,open=false": { "model": "securitycraft:block/keypad_trapdoor_bottom", "y": 90 },
+        "facing=north,half=top,open=false": { "model": "securitycraft:block/keypad_trapdoor_top", "y": 180 },
+        "facing=south,half=top,open=false": { "model": "securitycraft:block/keypad_trapdoor_top" },
+        "facing=east,half=top,open=false": { "model": "securitycraft:block/keypad_trapdoor_top", "y": 270 },
+        "facing=west,half=top,open=false": { "model": "securitycraft:block/keypad_trapdoor_top", "y": 90 },
+        "facing=north,half=bottom,open=true": { "model": "securitycraft:block/keypad_trapdoor_open", "z": 180 },
+        "facing=south,half=bottom,open=true": { "model": "securitycraft:block/keypad_trapdoor_open", "y": 180, "z": 180 },
+        "facing=east,half=bottom,open=true": { "model": "securitycraft:block/keypad_trapdoor_open", "y": 270, "z": 180 },
+        "facing=west,half=bottom,open=true": { "model": "securitycraft:block/keypad_trapdoor_open", "y": 90, "z": 180 },
+        "facing=north,half=top,open=true": { "model": "securitycraft:block/keypad_trapdoor_open" },
+        "facing=south,half=top,open=true": { "model": "securitycraft:block/keypad_trapdoor_open", "y": 180 },
+        "facing=east,half=top,open=true": { "model": "securitycraft:block/keypad_trapdoor_open", "y": 90 },
+        "facing=west,half=top,open=true": { "model": "securitycraft:block/keypad_trapdoor_open", "y": 270 }
+    }
 }

--- a/src/main/resources/assets/securitycraft/blockstates/keypad_trapdoor.json
+++ b/src/main/resources/assets/securitycraft/blockstates/keypad_trapdoor.json
@@ -1,20 +1,20 @@
 {
-    "variants": {
-        "facing=north,half=bottom,open=false": { "model": "securitycraft:block/keypad_trapdoor_bottom", "y": 180 },
-        "facing=south,half=bottom,open=false": { "model": "securitycraft:block/keypad_trapdoor_bottom" },
-        "facing=east,half=bottom,open=false": { "model": "securitycraft:block/keypad_trapdoor_bottom", "y": 270 },
-        "facing=west,half=bottom,open=false": { "model": "securitycraft:block/keypad_trapdoor_bottom", "y": 90 },
-        "facing=north,half=top,open=false": { "model": "securitycraft:block/keypad_trapdoor_top", "y": 180 },
-        "facing=south,half=top,open=false": { "model": "securitycraft:block/keypad_trapdoor_top" },
-        "facing=east,half=top,open=false": { "model": "securitycraft:block/keypad_trapdoor_top", "y": 270 },
-        "facing=west,half=top,open=false": { "model": "securitycraft:block/keypad_trapdoor_top", "y": 90 },
-        "facing=north,half=bottom,open=true": { "model": "securitycraft:block/keypad_trapdoor_open", "z": 180 },
-        "facing=south,half=bottom,open=true": { "model": "securitycraft:block/keypad_trapdoor_open", "y": 180, "z": 180 },
-        "facing=east,half=bottom,open=true": { "model": "securitycraft:block/keypad_trapdoor_open", "y": 90, "z": 180 },
-        "facing=west,half=bottom,open=true": { "model": "securitycraft:block/keypad_trapdoor_open", "y": 270, "z": 180 },
-        "facing=north,half=top,open=true": { "model": "securitycraft:block/keypad_trapdoor_open" },
-        "facing=south,half=top,open=true": { "model": "securitycraft:block/keypad_trapdoor_open", "y": 180 },
-        "facing=east,half=top,open=true": { "model": "securitycraft:block/keypad_trapdoor_open", "y": 90 },
-        "facing=west,half=top,open=true": { "model": "securitycraft:block/keypad_trapdoor_open", "y": 270 }
-    }
+	"variants": {
+		"facing=north,half=bottom,open=false": { "model": "securitycraft:block/keypad_trapdoor_bottom", "y": 180 },
+		"facing=south,half=bottom,open=false": { "model": "securitycraft:block/keypad_trapdoor_bottom" },
+		"facing=east,half=bottom,open=false": { "model": "securitycraft:block/keypad_trapdoor_bottom", "y": 270 },
+		"facing=west,half=bottom,open=false": { "model": "securitycraft:block/keypad_trapdoor_bottom", "y": 90 },
+		"facing=north,half=top,open=false": { "model": "securitycraft:block/keypad_trapdoor_top", "y": 180 },
+		"facing=south,half=top,open=false": { "model": "securitycraft:block/keypad_trapdoor_top" },
+		"facing=east,half=top,open=false": { "model": "securitycraft:block/keypad_trapdoor_top", "y": 270 },
+		"facing=west,half=top,open=false": { "model": "securitycraft:block/keypad_trapdoor_top", "y": 90 },
+		"facing=north,half=bottom,open=true": { "model": "securitycraft:block/keypad_trapdoor_open", "z": 180 },
+		"facing=south,half=bottom,open=true": { "model": "securitycraft:block/keypad_trapdoor_open", "y": 180, "z": 180 },
+		"facing=east,half=bottom,open=true": { "model": "securitycraft:block/keypad_trapdoor_open", "y": 270, "z": 180 },
+		"facing=west,half=bottom,open=true": { "model": "securitycraft:block/keypad_trapdoor_open", "y": 90, "z": 180 },
+		"facing=north,half=top,open=true": { "model": "securitycraft:block/keypad_trapdoor_open" },
+		"facing=south,half=top,open=true": { "model": "securitycraft:block/keypad_trapdoor_open", "y": 180 },
+		"facing=east,half=top,open=true": { "model": "securitycraft:block/keypad_trapdoor_open", "y": 90 },
+		"facing=west,half=top,open=true": { "model": "securitycraft:block/keypad_trapdoor_open", "y": 270 }
+	}
 }

--- a/src/main/resources/assets/securitycraft/blockstates/reinforced_iron_trapdoor.json
+++ b/src/main/resources/assets/securitycraft/blockstates/reinforced_iron_trapdoor.json
@@ -1,20 +1,20 @@
 {
-    "variants": {
-        "facing=north,half=bottom,open=false": { "model": "securitycraft:block/reinforced_iron_trapdoor_bottom", "y": 180 },
-        "facing=south,half=bottom,open=false": { "model": "securitycraft:block/reinforced_iron_trapdoor_bottom" },
-        "facing=east,half=bottom,open=false": { "model": "securitycraft:block/reinforced_iron_trapdoor_bottom", "y": 270 },
-        "facing=west,half=bottom,open=false": { "model": "securitycraft:block/reinforced_iron_trapdoor_bottom", "y": 90 },
-        "facing=north,half=top,open=false": { "model": "securitycraft:block/reinforced_iron_trapdoor_top", "y": 180 },
-        "facing=south,half=top,open=false": { "model": "securitycraft:block/reinforced_iron_trapdoor_top" },
-        "facing=east,half=top,open=false": { "model": "securitycraft:block/reinforced_iron_trapdoor_top", "y": 270 },
-        "facing=west,half=top,open=false": { "model": "securitycraft:block/reinforced_iron_trapdoor_top", "y": 90 },
-        "facing=north,half=bottom,open=true": { "model": "securitycraft:block/reinforced_iron_trapdoor_open", "z": 180 },
-        "facing=south,half=bottom,open=true": { "model": "securitycraft:block/reinforced_iron_trapdoor_open", "y": 180, "z": 180 },
-        "facing=east,half=bottom,open=true": { "model": "securitycraft:block/reinforced_iron_trapdoor_open", "y": 90, "z": 180 },
-        "facing=west,half=bottom,open=true": { "model": "securitycraft:block/reinforced_iron_trapdoor_open", "y": 270, "z": 180 },
-        "facing=north,half=top,open=true": { "model": "securitycraft:block/reinforced_iron_trapdoor_open" },
-        "facing=south,half=top,open=true": { "model": "securitycraft:block/reinforced_iron_trapdoor_open", "y": 180 },
-        "facing=east,half=top,open=true": { "model": "securitycraft:block/reinforced_iron_trapdoor_open", "y": 90 },
-        "facing=west,half=top,open=true": { "model": "securitycraft:block/reinforced_iron_trapdoor_open", "y": 270 }
-    }
+	"variants": {
+		"facing=north,half=bottom,open=false": { "model": "securitycraft:block/reinforced_iron_trapdoor_bottom", "y": 180 },
+		"facing=south,half=bottom,open=false": { "model": "securitycraft:block/reinforced_iron_trapdoor_bottom" },
+		"facing=east,half=bottom,open=false": { "model": "securitycraft:block/reinforced_iron_trapdoor_bottom", "y": 270 },
+		"facing=west,half=bottom,open=false": { "model": "securitycraft:block/reinforced_iron_trapdoor_bottom", "y": 90 },
+		"facing=north,half=top,open=false": { "model": "securitycraft:block/reinforced_iron_trapdoor_top", "y": 180 },
+		"facing=south,half=top,open=false": { "model": "securitycraft:block/reinforced_iron_trapdoor_top" },
+		"facing=east,half=top,open=false": { "model": "securitycraft:block/reinforced_iron_trapdoor_top", "y": 270 },
+		"facing=west,half=top,open=false": { "model": "securitycraft:block/reinforced_iron_trapdoor_top", "y": 90 },
+		"facing=north,half=bottom,open=true": { "model": "securitycraft:block/reinforced_iron_trapdoor_open", "z": 180 },
+		"facing=south,half=bottom,open=true": { "model": "securitycraft:block/reinforced_iron_trapdoor_open", "y": 180, "z": 180 },
+		"facing=east,half=bottom,open=true": { "model": "securitycraft:block/reinforced_iron_trapdoor_open", "y": 270, "z": 180 },
+		"facing=west,half=bottom,open=true": { "model": "securitycraft:block/reinforced_iron_trapdoor_open", "y": 90, "z": 180 },
+		"facing=north,half=top,open=true": { "model": "securitycraft:block/reinforced_iron_trapdoor_open" },
+		"facing=south,half=top,open=true": { "model": "securitycraft:block/reinforced_iron_trapdoor_open", "y": 180 },
+		"facing=east,half=top,open=true": { "model": "securitycraft:block/reinforced_iron_trapdoor_open", "y": 90 },
+		"facing=west,half=top,open=true": { "model": "securitycraft:block/reinforced_iron_trapdoor_open", "y": 270 }
+	}
 }

--- a/src/main/resources/assets/securitycraft/blockstates/reinforced_iron_trapdoor.json
+++ b/src/main/resources/assets/securitycraft/blockstates/reinforced_iron_trapdoor.json
@@ -1,20 +1,20 @@
 {
-	"variants": {
-		"facing=north,half=bottom,open=false": { "model": "securitycraft:block/reinforced_iron_trapdoor_bottom", "y": 180 },
-		"facing=south,half=bottom,open=false": { "model": "securitycraft:block/reinforced_iron_trapdoor_bottom" },
-		"facing=east,half=bottom,open=false": { "model": "securitycraft:block/reinforced_iron_trapdoor_bottom", "y": 270 },
-		"facing=west,half=bottom,open=false": { "model": "securitycraft:block/reinforced_iron_trapdoor_bottom", "y": 90 },
-		"facing=north,half=top,open=false": { "model": "securitycraft:block/reinforced_iron_trapdoor_top", "y": 180 },
-		"facing=south,half=top,open=false": { "model": "securitycraft:block/reinforced_iron_trapdoor_top" },
-		"facing=east,half=top,open=false": { "model": "securitycraft:block/reinforced_iron_trapdoor_top", "y": 270 },
-		"facing=west,half=top,open=false": { "model": "securitycraft:block/reinforced_iron_trapdoor_top", "y": 90 },
-		"facing=north,half=bottom,open=true": { "model": "securitycraft:block/reinforced_iron_trapdoor_open", "z": 180 },
-		"facing=south,half=bottom,open=true": { "model": "securitycraft:block/reinforced_iron_trapdoor_open", "y": 180, "z": 180 },
-		"facing=east,half=bottom,open=true": { "model": "securitycraft:block/reinforced_iron_trapdoor_open", "y": 270, "z": 180 },
-		"facing=west,half=bottom,open=true": { "model": "securitycraft:block/reinforced_iron_trapdoor_open", "y": 90, "z": 180 },
-		"facing=north,half=top,open=true": { "model": "securitycraft:block/reinforced_iron_trapdoor_open" },
-		"facing=south,half=top,open=true": { "model": "securitycraft:block/reinforced_iron_trapdoor_open", "y": 180 },
-		"facing=east,half=top,open=true": { "model": "securitycraft:block/reinforced_iron_trapdoor_open", "y": 90 },
-		"facing=west,half=top,open=true": { "model": "securitycraft:block/reinforced_iron_trapdoor_open", "y": 270 }
-	}
+    "variants": {
+        "facing=north,half=bottom,open=false": { "model": "securitycraft:block/reinforced_iron_trapdoor_bottom", "y": 180 },
+        "facing=south,half=bottom,open=false": { "model": "securitycraft:block/reinforced_iron_trapdoor_bottom" },
+        "facing=east,half=bottom,open=false": { "model": "securitycraft:block/reinforced_iron_trapdoor_bottom", "y": 270 },
+        "facing=west,half=bottom,open=false": { "model": "securitycraft:block/reinforced_iron_trapdoor_bottom", "y": 90 },
+        "facing=north,half=top,open=false": { "model": "securitycraft:block/reinforced_iron_trapdoor_top", "y": 180 },
+        "facing=south,half=top,open=false": { "model": "securitycraft:block/reinforced_iron_trapdoor_top" },
+        "facing=east,half=top,open=false": { "model": "securitycraft:block/reinforced_iron_trapdoor_top", "y": 270 },
+        "facing=west,half=top,open=false": { "model": "securitycraft:block/reinforced_iron_trapdoor_top", "y": 90 },
+        "facing=north,half=bottom,open=true": { "model": "securitycraft:block/reinforced_iron_trapdoor_open", "z": 180 },
+        "facing=south,half=bottom,open=true": { "model": "securitycraft:block/reinforced_iron_trapdoor_open", "y": 180, "z": 180 },
+        "facing=east,half=bottom,open=true": { "model": "securitycraft:block/reinforced_iron_trapdoor_open", "y": 270, "z": 180 },
+        "facing=west,half=bottom,open=true": { "model": "securitycraft:block/reinforced_iron_trapdoor_open", "y": 90, "z": 180 },
+        "facing=north,half=top,open=true": { "model": "securitycraft:block/reinforced_iron_trapdoor_open" },
+        "facing=south,half=top,open=true": { "model": "securitycraft:block/reinforced_iron_trapdoor_open", "y": 180 },
+        "facing=east,half=top,open=true": { "model": "securitycraft:block/reinforced_iron_trapdoor_open", "y": 90 },
+        "facing=west,half=top,open=true": { "model": "securitycraft:block/reinforced_iron_trapdoor_open", "y": 270 }
+    }
 }

--- a/src/main/resources/assets/securitycraft/blockstates/scanner_trapdoor.json
+++ b/src/main/resources/assets/securitycraft/blockstates/scanner_trapdoor.json
@@ -1,20 +1,20 @@
 {
-    "variants": {
-        "facing=north,half=bottom,open=false": { "model": "securitycraft:block/scanner_trapdoor_bottom", "y": 180 },
-        "facing=south,half=bottom,open=false": { "model": "securitycraft:block/scanner_trapdoor_bottom" },
-        "facing=east,half=bottom,open=false": { "model": "securitycraft:block/scanner_trapdoor_bottom", "y": 270 },
-        "facing=west,half=bottom,open=false": { "model": "securitycraft:block/scanner_trapdoor_bottom", "y": 90 },
-        "facing=north,half=top,open=false": { "model": "securitycraft:block/scanner_trapdoor_top", "y": 180 },
-        "facing=south,half=top,open=false": { "model": "securitycraft:block/scanner_trapdoor_top" },
-        "facing=east,half=top,open=false": { "model": "securitycraft:block/scanner_trapdoor_top", "y": 270 },
-        "facing=west,half=top,open=false": { "model": "securitycraft:block/scanner_trapdoor_top", "y": 90 },
-        "facing=north,half=bottom,open=true": { "model": "securitycraft:block/scanner_trapdoor_open", "z": 180 },
-        "facing=south,half=bottom,open=true": { "model": "securitycraft:block/scanner_trapdoor_open", "y": 180, "z": 180 },
-        "facing=east,half=bottom,open=true": { "model": "securitycraft:block/scanner_trapdoor_open", "y": 90, "z": 180 },
-        "facing=west,half=bottom,open=true": { "model": "securitycraft:block/scanner_trapdoor_open", "y": 270, "z": 180 },
-        "facing=north,half=top,open=true": { "model": "securitycraft:block/scanner_trapdoor_open" },
-        "facing=south,half=top,open=true": { "model": "securitycraft:block/scanner_trapdoor_open", "y": 180 },
-        "facing=east,half=top,open=true": { "model": "securitycraft:block/scanner_trapdoor_open", "y": 90 },
-        "facing=west,half=top,open=true": { "model": "securitycraft:block/scanner_trapdoor_open", "y": 270 }
-    }
+	"variants": {
+		"facing=north,half=bottom,open=false": { "model": "securitycraft:block/scanner_trapdoor_bottom", "y": 180 },
+		"facing=south,half=bottom,open=false": { "model": "securitycraft:block/scanner_trapdoor_bottom" },
+		"facing=east,half=bottom,open=false": { "model": "securitycraft:block/scanner_trapdoor_bottom", "y": 270 },
+		"facing=west,half=bottom,open=false": { "model": "securitycraft:block/scanner_trapdoor_bottom", "y": 90 },
+		"facing=north,half=top,open=false": { "model": "securitycraft:block/scanner_trapdoor_top", "y": 180 },
+		"facing=south,half=top,open=false": { "model": "securitycraft:block/scanner_trapdoor_top" },
+		"facing=east,half=top,open=false": { "model": "securitycraft:block/scanner_trapdoor_top", "y": 270 },
+		"facing=west,half=top,open=false": { "model": "securitycraft:block/scanner_trapdoor_top", "y": 90 },
+		"facing=north,half=bottom,open=true": { "model": "securitycraft:block/scanner_trapdoor_open", "z": 180 },
+		"facing=south,half=bottom,open=true": { "model": "securitycraft:block/scanner_trapdoor_open", "y": 180, "z": 180 },
+		"facing=east,half=bottom,open=true": { "model": "securitycraft:block/scanner_trapdoor_open", "y": 270, "z": 180 },
+		"facing=west,half=bottom,open=true": { "model": "securitycraft:block/scanner_trapdoor_open", "y": 90, "z": 180 },
+		"facing=north,half=top,open=true": { "model": "securitycraft:block/scanner_trapdoor_open" },
+		"facing=south,half=top,open=true": { "model": "securitycraft:block/scanner_trapdoor_open", "y": 180 },
+		"facing=east,half=top,open=true": { "model": "securitycraft:block/scanner_trapdoor_open", "y": 90 },
+		"facing=west,half=top,open=true": { "model": "securitycraft:block/scanner_trapdoor_open", "y": 270 }
+	}
 }

--- a/src/main/resources/assets/securitycraft/blockstates/scanner_trapdoor.json
+++ b/src/main/resources/assets/securitycraft/blockstates/scanner_trapdoor.json
@@ -1,20 +1,20 @@
 {
-	"variants": {
-		"facing=north,half=bottom,open=false": { "model": "securitycraft:block/scanner_trapdoor_bottom", "y": 180 },
-		"facing=south,half=bottom,open=false": { "model": "securitycraft:block/scanner_trapdoor_bottom" },
-		"facing=east,half=bottom,open=false": { "model": "securitycraft:block/scanner_trapdoor_bottom", "y": 270 },
-		"facing=west,half=bottom,open=false": { "model": "securitycraft:block/scanner_trapdoor_bottom", "y": 90 },
-		"facing=north,half=top,open=false": { "model": "securitycraft:block/scanner_trapdoor_top", "y": 180 },
-		"facing=south,half=top,open=false": { "model": "securitycraft:block/scanner_trapdoor_top" },
-		"facing=east,half=top,open=false": { "model": "securitycraft:block/scanner_trapdoor_top", "y": 270 },
-		"facing=west,half=top,open=false": { "model": "securitycraft:block/scanner_trapdoor_top", "y": 90 },
-		"facing=north,half=bottom,open=true": { "model": "securitycraft:block/scanner_trapdoor_open", "z": 180 },
-		"facing=south,half=bottom,open=true": { "model": "securitycraft:block/scanner_trapdoor_open", "y": 180, "z": 180 },
-		"facing=east,half=bottom,open=true": { "model": "securitycraft:block/scanner_trapdoor_open", "y": 270, "z": 180 },
-		"facing=west,half=bottom,open=true": { "model": "securitycraft:block/scanner_trapdoor_open", "y": 90, "z": 180 },
-		"facing=north,half=top,open=true": { "model": "securitycraft:block/scanner_trapdoor_open" },
-		"facing=south,half=top,open=true": { "model": "securitycraft:block/scanner_trapdoor_open", "y": 180 },
-		"facing=east,half=top,open=true": { "model": "securitycraft:block/scanner_trapdoor_open", "y": 90 },
-		"facing=west,half=top,open=true": { "model": "securitycraft:block/scanner_trapdoor_open", "y": 270 }
-	}
+    "variants": {
+        "facing=north,half=bottom,open=false": { "model": "securitycraft:block/scanner_trapdoor_bottom", "y": 180 },
+        "facing=south,half=bottom,open=false": { "model": "securitycraft:block/scanner_trapdoor_bottom" },
+        "facing=east,half=bottom,open=false": { "model": "securitycraft:block/scanner_trapdoor_bottom", "y": 270 },
+        "facing=west,half=bottom,open=false": { "model": "securitycraft:block/scanner_trapdoor_bottom", "y": 90 },
+        "facing=north,half=top,open=false": { "model": "securitycraft:block/scanner_trapdoor_top", "y": 180 },
+        "facing=south,half=top,open=false": { "model": "securitycraft:block/scanner_trapdoor_top" },
+        "facing=east,half=top,open=false": { "model": "securitycraft:block/scanner_trapdoor_top", "y": 270 },
+        "facing=west,half=top,open=false": { "model": "securitycraft:block/scanner_trapdoor_top", "y": 90 },
+        "facing=north,half=bottom,open=true": { "model": "securitycraft:block/scanner_trapdoor_open", "z": 180 },
+        "facing=south,half=bottom,open=true": { "model": "securitycraft:block/scanner_trapdoor_open", "y": 180, "z": 180 },
+        "facing=east,half=bottom,open=true": { "model": "securitycraft:block/scanner_trapdoor_open", "y": 270, "z": 180 },
+        "facing=west,half=bottom,open=true": { "model": "securitycraft:block/scanner_trapdoor_open", "y": 90, "z": 180 },
+        "facing=north,half=top,open=true": { "model": "securitycraft:block/scanner_trapdoor_open" },
+        "facing=south,half=top,open=true": { "model": "securitycraft:block/scanner_trapdoor_open", "y": 180 },
+        "facing=east,half=top,open=true": { "model": "securitycraft:block/scanner_trapdoor_open", "y": 90 },
+        "facing=west,half=top,open=true": { "model": "securitycraft:block/scanner_trapdoor_open", "y": 270 }
+    }
 }


### PR DESCRIPTION
Fix trapdoors facing the wrong direction visually when placed facing west or east. Should resolve #620.

Tested it in game and looks correct in all directions.

I can open pull requests for the 26.1 and 1.21.11 branch too since they were affected too if you need.