### PR TITLE
Fix synchronization issues between connected inventory scanners

### DIFF
--- a/src/main/java/net/geforcemods/securitycraft/blockentities/InventoryScannerBlockEntity.java
+++ b/src/main/java/net/geforcemods/securitycraft/blockentities/InventoryScannerBlockEntity.java
@@ -318,6 +318,12 @@ public class InventoryScannerBlockEntity extends DisguisableBlockEntity implemen
 				if (connectedScanner != null)
 					connectedScanner.setSignalLength(io.get());
 			}
+			case BooleanOption bo when option == respectInvisibility -> {
+				InventoryScannerBlockEntity connectedScanner = InventoryScannerBlock.getConnectedInventoryScanner(level, worldPosition);
+
+				if (connectedScanner != null)
+					connectedScanner.setRespectInvisibility(bo.get());
+			}
 			default ->
 					throw new UnsupportedOperationException("Unhandled option synchronization in inventory scanner! " + option.getName());
 		}
@@ -407,6 +413,18 @@ public class InventoryScannerBlockEntity extends DisguisableBlockEntity implemen
 
 	public int getSignalLength() {
 		return signalLength.get();
+	}
+
+	public boolean respectInvisibility() {
+		return respectInvisibility.get();
+	}
+
+	public void setRespectInvisibility(boolean respectInvisibility) {
+		if (respectInvisibility() != respectInvisibility) {
+			this.respectInvisibility.setValue(respectInvisibility);
+			level.sendBlockUpdated(worldPosition, getBlockState(), getBlockState(), 3); //sync option change to client
+			setChanged();
+		}
 	}
 
 	public boolean isConsideredInvisible(LivingEntity entity) {

--- a/src/main/java/net/geforcemods/securitycraft/blocks/InventoryScannerBlock.java
+++ b/src/main/java/net/geforcemods/securitycraft/blocks/InventoryScannerBlock.java
@@ -102,10 +102,7 @@ public class InventoryScannerBlock extends DisguisableBlock {
 			connectedScanner.setDisabled(false);
 		}
 
-		boolean horizontal = false;
-
-		if (connectedScanner.getBlockState().getValue(HORIZONTAL))
-			horizontal = true;
+		connectedScanner.setHorizontal(thisBe.isHorizontal());
 
 		Direction facing = level.getBlockState(pos).getValue(FACING);
 		int loopBoundary = switch (facing) {
@@ -113,8 +110,6 @@ public class InventoryScannerBlock extends DisguisableBlock {
 			case NORTH, SOUTH -> Math.abs(pos.getZ() - connectedScanner.getBlockPos().getZ());
 			default -> 0;
 		};
-
-		thisBe.setHorizontal(horizontal);
 
 		for (int i = 1; i < loopBoundary; i++) {
 			if (level.getBlockState(pos.relative(facing, i)).getBlock() == SCContent.INVENTORY_SCANNER_FIELD.get())
@@ -126,7 +121,7 @@ public class InventoryScannerBlock extends DisguisableBlock {
 		for (int i = 1; i < loopBoundary; i++) {
 			BlockPos offsetPos = pos.relative(facing, i);
 
-			level.setBlockAndUpdate(offsetPos, SCContent.INVENTORY_SCANNER_FIELD.get().defaultBlockState().setValue(FACING, facing).setValue(HORIZONTAL, horizontal).setValue(WATERLOGGED, level.getFluidState(pos).getType() == Fluids.WATER));
+			level.setBlockAndUpdate(offsetPos, SCContent.INVENTORY_SCANNER_FIELD.get().defaultBlockState().setValue(FACING, facing).setValue(HORIZONTAL, thisBe.isHorizontal()).setValue(WATERLOGGED, level.getFluidState(pos).getType() == Fluids.WATER));
 
 			if (level.getBlockEntity(offsetPos) instanceof IOwnable ownable)
 				ownable.setOwner(thisBe.getOwner().getUUID(), thisBe.getOwner().getName());
@@ -136,7 +131,7 @@ public class InventoryScannerBlock extends DisguisableBlock {
 			thisBe.insertModule(connectedScanner.getModule(type), false);
 		}
 
-		((BooleanOption) customOptions[0]).setValue(connectedScanner.isHorizontal());
+		((BooleanOption) customOptions[0]).setValue(thisBe.isHorizontal());
 		((BooleanOption) customOptions[1]).setValue(connectedScanner.doesFieldSolidify());
 		((BooleanOption) customOptions[2]).setValue(false);
 	}


### PR DESCRIPTION
There was a synchronization issue between connected inventory scanners, some configuration changes in the universal block modifier menu didn't get synchronized.

- Horizontal: The horizontal configuration option didn't get synchronized in the configuration menu and in textures (E.g.: setting horizontal to `true` on side A flips the fields and side A's texture but on side B the texture still looks vertical and if you check the configuration menu the value doesn't update.)
- Respect Invisibility: The toggle only worked on the first placed side of a pair of inventory scanners, the other one was ignored and not synced.