### PR TITLE
Fix inventory scanner removing some items from owner

### DIFF
--- a/src/main/java/net/geforcemods/securitycraft/blocks/InventoryScannerFieldBlock.java
+++ b/src/main/java/net/geforcemods/securitycraft/blocks/InventoryScannerFieldBlock.java
@@ -102,8 +102,12 @@ public class InventoryScannerFieldBlock extends OwnableBlock implements SimpleWa
 		if (entity instanceof LivingEntity living && !be.isConsideredInvisible(living) && !be.isAllowed(entity)) {
 			boolean foundItem;
 
-			if (living instanceof Player player && (!be.isOwnedBy(player) || !be.ignoresOwner())) {
+			if (living instanceof Player player) {
 				player.closeContainer(); //Fixes item smuggling using nearby containers
+
+				if (be.isOwnedBy(player) && be.ignoresOwner()) {
+					return false;
+				}
 
 				foundItem = checkInventory(ItemAccess.forContainer(player.getInventory()), be, allowInteraction);
 


### PR DESCRIPTION
Fix the inventory scanner removing some items from the owner (specifically the mainhand, offhand and armorslots) while IgnoreOwner is true.