### PR TITLE
Fix SRI rotation being wrong when placed on walls.

### DIFF
--- a/src/main/java/net/geforcemods/securitycraft/ClientHandler.java
+++ b/src/main/java/net/geforcemods/securitycraft/ClientHandler.java
@@ -796,9 +796,9 @@ public class ClientHandler {
 				case DOWN -> OctahedralGroup.BLOCK_ROT_X_180;
 				case UP -> OctahedralGroup.IDENTITY;
 				case NORTH -> OctahedralGroup.BLOCK_ROT_X_90;
-				case SOUTH -> OctahedralGroup.BLOCK_ROT_X_90.compose(OctahedralGroup.BLOCK_ROT_Y_180);
-				case WEST -> OctahedralGroup.BLOCK_ROT_X_90.compose(OctahedralGroup.BLOCK_ROT_Y_270);
-				case EAST -> OctahedralGroup.BLOCK_ROT_X_90.compose(OctahedralGroup.BLOCK_ROT_Y_90);
+				case SOUTH -> OctahedralGroup.BLOCK_ROT_Y_180.compose(OctahedralGroup.BLOCK_ROT_X_90);
+				case WEST -> OctahedralGroup.BLOCK_ROT_Y_270.compose(OctahedralGroup.BLOCK_ROT_X_90);
+				case EAST -> OctahedralGroup.BLOCK_ROT_Y_90.compose(OctahedralGroup.BLOCK_ROT_X_90);
 			});
 		}
 	}


### PR DESCRIPTION
Fix the Secure Redstone Interface's base rotation being on when powered and placed on walls.